### PR TITLE
Use JVM 19 Buffer Recycling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ build/
 *.iml
 .gradle
 *.prefs
-jsonb-generator/.classpath
-jsonb-generator/.project
+*.classpath
+*.project
+*.class

--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -13,9 +13,9 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <java.version>19</java.version>
-    <maven.compiler.source>19</maven.compiler.source>
-    <maven.compiler.target>19</maven.compiler.target>
+    <java.version>17</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -13,9 +13,9 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <java.version>17</java.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>19</java.version>
+    <maven.compiler.source>19</maven.compiler.source>
+    <maven.compiler.target>19</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JsonStream.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JsonStream.java
@@ -112,12 +112,8 @@ public final class JsonStream implements JsonStreamAdapter {
 
   @Override
   public JsonReader reader(InputStream inputStream) {
-    try {
-      JsonParser parser = Recycle.parser(inputStream);
-      return new JsonReadAdapter(parser, failOnUnknown);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    JsonParser parser = Recycle.parser(inputStream);
+    return new JsonReadAdapter(parser, failOnUnknown);
   }
 
   @Override

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -43,9 +43,11 @@ final class Recycle {
   }
 
   static JParser getParser() {
+    final char[] ch = new char[4096];
+    final byte[] by = new byte[4096];
     return new JParser(
-        new char[4096],
-        new byte[4096],
+        ch,
+        by,
         0,
         JParser.ErrorInfo.MINIMAL,
         JParser.DoublePrecision.DEFAULT,

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -43,11 +43,9 @@ final class Recycle {
   }
 
   static JParser getParser() {
-    final char[] ch = new char[4096];
-    final byte[] by = new byte[4096];
     return new JParser(
-        ch,
-        by,
+        new char[4096],
+        new byte[4096],
         0,
         JParser.ErrorInfo.MINIMAL,
         JParser.DoublePrecision.DEFAULT,

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -11,15 +11,11 @@ final class Recycle {
   private static ThreadLocal<JParser> read;
 
   static {
-    try {
-      if (Float.parseFloat(System.getProperty("java.version")) >= 19) {
-        jvmRecycle = true;
-      } else {
-        managed = ThreadLocal.withInitial(Recycle::getGenerator);
-        read = ThreadLocal.withInitial(Recycle::getParser);
-      }
-    } catch (final Exception e) {
-      e.printStackTrace();
+    if (Float.parseFloat(System.getProperty("java.specification.version")) >= 19) {
+      jvmRecycle = true;
+    } else {
+      managed = ThreadLocal.withInitial(Recycle::getGenerator);
+      read = ThreadLocal.withInitial(Recycle::getParser);
     }
   }
 

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -1,38 +1,62 @@
 package io.avaje.jsonb.stream;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.concurrent.Executors;
 
 final class Recycle {
+  private Recycle() {}
 
-  static ThreadLocal<JGenerator> managed = ThreadLocal.withInitial(() -> new JGenerator(4096));
+  private static boolean virtualThreads;
+  private static ThreadLocal<JGenerator> managed;
+  private static ThreadLocal<JParser> read;
 
-  static ThreadLocal<JParser> read = ThreadLocal.withInitial(() -> {
-    char[] ch = new char[4096];
-    byte[] by = new byte[4096];
-    return new JParser(ch, by, 0, JParser.ErrorInfo.MINIMAL, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 50_000);
-  });
-
-  /**
-   * Return a recycled generator with the given target OutputStream.
-   */
-  static JsonGenerator generator(OutputStream target) {
-    return managed.get().prepare(target);
+  static {
+    try {
+      Executors.class.getMethod("newVirtualThreadPerTaskExecutor").invoke(Executors.class);
+      virtualThreads = true;
+    } catch (final Exception e) {
+      virtualThreads = false;
+    }
+    if (!virtualThreads) {
+      managed = ThreadLocal.withInitial(Recycle::getGenerator);
+      read = ThreadLocal.withInitial(Recycle::getParser);
+    }
   }
 
-  /**
-   * Return a recycled generator with expected "to String" result.
-   */
+  /** Return a recycled generator with the given target OutputStream. */
+  static JsonGenerator generator(OutputStream target) {
+    return (virtualThreads ? getGenerator() : managed.get()).prepare(target);
+  }
+
+  /** Return a recycled generator with expected "to String" result. */
   static JsonGenerator generator() {
-    return managed.get().prepare(null);
+    return (virtualThreads ? getGenerator() : managed.get()).prepare(null);
   }
 
   static JsonParser parser(byte[] bytes) {
-    return read.get().process(bytes, bytes.length);
+    return (virtualThreads ? getParser() : read.get()).process(bytes, bytes.length);
   }
 
-  static JsonParser parser(InputStream in) throws IOException {
-    return read.get().process(in);
+  static JsonParser parser(InputStream in) {
+    return (virtualThreads ? getParser() : read.get()).process(in);
+  }
+
+  static JGenerator getGenerator() {
+    return new JGenerator(4096);
+  }
+
+  static JParser getParser() {
+    final char[] ch = new char[4096];
+    final byte[] by = new byte[4096];
+    return new JParser(
+        ch,
+        by,
+        0,
+        JParser.ErrorInfo.MINIMAL,
+        JParser.DoublePrecision.DEFAULT,
+        JParser.UnknownNumberParsing.BIGDECIMAL,
+        100,
+        50_000);
   }
 }

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -11,7 +11,7 @@ final class Recycle {
   private static ThreadLocal<JParser> read;
 
   static {
-    if (Integer.getInteger("java.version") >= 19) {
+    if (Float.parseFloat(System.getProperty("java.version")) >= 19) {
       jvmRecycle = true;
     } else {
       managed = ThreadLocal.withInitial(Recycle::getGenerator);

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -7,11 +7,12 @@ final class Recycle {
   private Recycle() {}
 
   private static boolean jvmRecycle;
-  private static ThreadLocal<JGenerator> managed;
   private static ThreadLocal<JParser> read;
+  private static ThreadLocal<JGenerator> managed;
 
   static {
-    if (Float.parseFloat(System.getProperty("java.specification.version")) >= 19) {
+    if (Float.parseFloat(System.getProperty("java.specification.version")) >= 19
+        && !Boolean.getBoolean("jsonb.UseTLBuffers")) {
       jvmRecycle = true;
     } else {
       managed = ThreadLocal.withInitial(Recycle::getGenerator);

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/Recycle.java
@@ -11,11 +11,15 @@ final class Recycle {
   private static ThreadLocal<JParser> read;
 
   static {
-    if (Float.parseFloat(System.getProperty("java.version")) >= 19) {
-      jvmRecycle = true;
-    } else {
-      managed = ThreadLocal.withInitial(Recycle::getGenerator);
-      read = ThreadLocal.withInitial(Recycle::getParser);
+    try {
+      if (Float.parseFloat(System.getProperty("java.version")) >= 19) {
+        jvmRecycle = true;
+      } else {
+        managed = ThreadLocal.withInitial(Recycle::getGenerator);
+        read = ThreadLocal.withInitial(Recycle::getParser);
+      }
+    } catch (final Exception e) {
+      e.printStackTrace();
     }
   }
 


### PR DESCRIPTION
Benched using https://github.com/fabienrenaud/java-json-benchmark

![image](https://user-images.githubusercontent.com/32279667/200443449-5f2490af-fef3-44d9-ae17-b3cf679ce8e6.png)

Here are the current benchmarks with no changes
![asIs](https://user-images.githubusercontent.com/32279667/200443138-898aba13-7f3d-4c5d-bd71-58e00daf526b.PNG)
![AsIsSer](https://user-images.githubusercontent.com/32279667/200443181-5cbe2ed9-59da-49af-91ae-c0511120efb1.PNG)
Benchmarks without ThreadLocal and using JVM Recycle 
![JVMRecycleDes](https://user-images.githubusercontent.com/32279667/200443844-58495adb-0ad0-4cf4-a820-a18b86d3e14b.PNG)
![JVMRecycleSer](https://user-images.githubusercontent.com/32279667/200443907-32d5c59b-8e24-4fe0-a107-874b2910af23.PNG)


part of #37