### PR TITLE
Fix to JsonWriter to not flush underlying outputStream when error during serialisation

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/IErrOnRead.java
+++ b/blackbox-test/src/main/java/org/example/customer/IErrOnRead.java
@@ -1,0 +1,13 @@
+package org.example.customer;
+
+import io.avaje.jsonb.Json;
+
+import java.util.UUID;
+
+@Json
+public record IErrOnRead(UUID id, String firstName, String lastName) {
+
+  public String lastName() {
+    throw new IllegalArgumentException("error reading lastName");
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/IErrOnReadTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/IErrOnReadTest.java
@@ -1,0 +1,29 @@
+package org.example.customer;
+
+import io.avaje.jsonb.JsonException;
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IErrOnReadTest {
+
+  @Test
+  void toJson_withError() {
+    IErrOnRead bean = new IErrOnRead(UUID.randomUUID(), "first", "last");
+    Jsonb jsonb = Jsonb.builder().build();
+    JsonType<IErrOnRead> type = jsonb.type(IErrOnRead.class);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      type.toJson(bean, baos);
+    } catch (JsonException expectedForTest) {
+      assertThat(expectedForTest.getCause()).hasMessage("error reading lastName");
+    }
+    assertThat(baos.toByteArray()).describedAs("no flush to outputStream expected").hasSize(0);
+  }
+}

--- a/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
+++ b/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
@@ -30,6 +30,14 @@ final class JacksonWriter implements JsonWriter {
   }
 
   @Override
+  public void markIncomplete() {
+    // on close don't flush or close the underlying OutputStream
+    generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+    generator.disable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
+    generator.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+  }
+
+  @Override
   public void close() {
     try {
       generator.close();

--- a/jsonb/src/main/java/io/avaje/jsonb/JsonWriter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/JsonWriter.java
@@ -228,4 +228,11 @@ public interface JsonWriter extends Closeable, Flushable {
    */
   void close();
 
+  /**
+   * Mark the generated json as not completed due to an error.
+   * <p>
+   * This typically means not to flush or close an underlying OutputStream which
+   * allows it to be reset to then write some error response content instead.
+   */
+  void markIncomplete();
 }

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonType.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonType.java
@@ -75,20 +75,25 @@ class DJsonType<T> implements JsonType<T> {
 
   @Override
   public final void toJson(T value, JsonWriter writer) {
-    adapter.toJson(writer, value);
+    try {
+      adapter.toJson(writer, value);
+    } catch (RuntimeException e) {
+      writer.markIncomplete();
+      throw new JsonException(e);
+    }
   }
 
   @Override
   public final void toJson(T value, Writer writer) {
     try (JsonWriter jsonWriter = jsonb.writer(writer)) {
-      adapter.toJson(jsonWriter, value);
+      toJson(value, jsonWriter);
     }
   }
 
   @Override
   public final void toJson(T value, OutputStream outputStream) {
     try (JsonWriter writer = jsonb.writer(outputStream)) {
-      adapter.toJson(writer, value);
+      toJson(value, writer);
     }
     close(outputStream);
   }

--- a/jsonb/src/main/java/io/avaje/jsonb/spi/DelegateJsonWriter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/spi/DelegateJsonWriter.java
@@ -186,4 +186,8 @@ public abstract class DelegateJsonWriter implements JsonWriter {
     delegate.close();
   }
 
+  @Override
+  public void markIncomplete() {
+    delegate.markIncomplete();
+  }
 }

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JGenerator.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JGenerator.java
@@ -63,6 +63,7 @@ final class JGenerator implements JsonGenerator {
   private final ArrayStack<JsonNames> nameStack = new ArrayStack<>();
   private JsonNames currentNames;
   private boolean allNames;
+  private boolean incomplete;
 
   JGenerator() {
     this(512);
@@ -83,6 +84,7 @@ final class JGenerator implements JsonGenerator {
     pretty = false;
     nameStack.clear();
     allNames = false;
+    incomplete = false;
     return this;
   }
 
@@ -382,6 +384,11 @@ final class JGenerator implements JsonGenerator {
   }
 
   @Override
+  public void markIncomplete() {
+    incomplete = true;
+  }
+
+  @Override
   public void flush() {
     if (target != null && position != 0) {
       try {
@@ -395,6 +402,7 @@ final class JGenerator implements JsonGenerator {
 
   @Override
   public void close() {
+    if (incomplete) return;
     flush();
     if (target != null) {
       try {

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JsonGenerator.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JsonGenerator.java
@@ -131,4 +131,8 @@ interface JsonGenerator extends Closeable, Flushable {
    */
   byte[] toByteArray();
 
+  /**
+   * Mark that json generation was not completed due to an error.
+   */
+  void markIncomplete();
 }

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JsonWriteAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JsonWriteAdapter.java
@@ -32,6 +32,11 @@ final class JsonWriteAdapter implements JsonWriter {
   }
 
   @Override
+  public void markIncomplete() {
+    generator.markIncomplete();
+  }
+
+  @Override
   public void close() {
     generator.close();
   }

--- a/jsonb/src/test/java/io/avaje/jsonb/stream/DieselAdapterTest.java
+++ b/jsonb/src/test/java/io/avaje/jsonb/stream/DieselAdapterTest.java
@@ -81,6 +81,27 @@ class DieselAdapterTest {
     assertThat(os1.toString()).isEqualTo("{\"one\":\"hi\"}");
   }
 
+  @Test
+  void write_markIncomplete_withError() {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    try {
+      try (JsonWriter jw = adapter.writer(os)) {
+        jw.beginObject();
+        jw.name("one");
+        jw.value("I will be incomplete");
+        jw.markIncomplete();
+        throwAnError();
+      }
+    } catch (Exception e) {
+      // ignore
+    }
+    assertThat(os.toString()).isEqualTo("");
+  }
+
+  private void throwAnError() {
+    throw new IllegalStateException("foo");
+  }
+
   private void writeHello(JsonWriter jw, String message) {
     jw.beginObject();
     jw.name("one");


### PR DESCRIPTION
- Adds markIncomplete() to indicate when an error has occurred during serialisation
- When not complete then do not flush to the underlying outputStream (so that it can be reset for sending error content)