### PR TITLE
Now @Ignore works when both serialize and deserialize are false

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
@@ -172,7 +172,7 @@ class BeanReader {
     }
     Set<String> uniqueTypes = new HashSet<>();
     for (FieldReader allField : allFields) {
-      if (allField.include() || !allField.isRaw()) {
+      if (allField.include() && !allField.isRaw()) {
         if (uniqueTypes.add(allField.adapterShortType())) {
           allField.writeConstructor(writer);
         }


### PR DESCRIPTION
The following fails to compile.
```
 @Json
 @Getter
 @Setter
  public class Person() {
  @Ignore
   private   String s;
   private   Instant time;
   private   int num;
}
```

It seems the adapter for the ignored String field is still getting added in the generated constructor, but not the fields.
```
  // naming convention Match
  // s [java.lang.String] name:s ignoreSerialize ignoreDeserialize
  // time [java.time.Instant] name:time constructor
  // sgsgs [int] name:sgsgs constructor

  private final JsonAdapter<Instant> instantJsonAdapter;
  private final JsonAdapter<Integer> pintJsonAdapter;
  private final PropertyNames names;

  public HelloController$PersonJsonAdapter(Jsonb jsonb) {
    this.stringJsonAdapter = jsonb.adapter(String.class);
    this.instantJsonAdapter = jsonb.adapter(Instant.class);
    this.pintJsonAdapter = jsonb.adapter(Integer.TYPE);

  ...rest is fine
```
