### PR TITLE
Add Json Alias annotation

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AliasReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AliasReader.java
@@ -1,0 +1,26 @@
+package io.avaje.jsonb.generator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+
+class AliasReader {
+
+  private static final String JSON_ALIAS = "io.avaje.jsonb.Json.JsonAlias";
+
+  /** Read the Json.Property annotation using annotation mirrors. */
+  static List<String> getAliases(Element element) {
+    for (final AnnotationMirror mirror : element.getAnnotationMirrors()) {
+      if (JSON_ALIAS.equals(mirror.getAnnotationType().toString())) {
+        return mirror.getElementValues().values().stream()
+            .flatMap(v -> ((List<?>) v.getValue()).stream())
+            .map(Object::toString)
+            .map(Util::trimQuotes)
+            .collect(Collectors.toList());
+      }
+    }
+    return null;
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AliasReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AliasReader.java
@@ -6,11 +6,12 @@ import java.util.stream.Collectors;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 
-class AliasReader {
+final class AliasReader {
+  private AliasReader() {}
 
   private static final String JSON_ALIAS = "io.avaje.jsonb.Json.JsonAlias";
 
-  /** Read the Json.Property annotation using annotation mirrors. */
+  /** Read the Json.Alias annotation using annotation mirrors. */
   static List<String> getAliases(Element element) {
     for (final AnnotationMirror mirror : element.getAnnotationMirrors()) {
       if (JSON_ALIAS.equals(mirror.getAnnotationType().toString())) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -31,6 +31,7 @@ class FieldReader {
   private boolean constructorParam;
   private boolean genericTypeParameter;
   private int genericTypeParamPosition;
+  private final List<String> aliases;
 
   FieldReader(Element element, NamingConvention namingConvention, TypeSubTypeMeta subType, List<String> genericTypeParams) {
     addSubType(subType);
@@ -39,6 +40,7 @@ class FieldReader {
     this.propertyName = PropertyReader.name(namingConvention, fieldName, element);
     this.publicField = element.getModifiers().contains(Modifier.PUBLIC);
     this.rawType = trimAnnotations(element.asType().toString());
+    this.aliases = AliasReader.getAliases(element);
 
     final PropertyIgnoreReader ignoreReader = new PropertyIgnoreReader(element);
     this.unmapped = ignoreReader.unmapped();
@@ -302,6 +304,15 @@ class FieldReader {
     if (unmapped) {
       return;
     }
+
+    if (aliases != null) {
+
+      for (final String alias : aliases) {
+        writer.append("        case \"%s\":", alias);
+        writer.eol();
+      }
+    }
+
     writer.append("        case \"%s\": {", propertyName).eol();
     if (!deserialize) {
       writer.append("          reader.skipValue();");

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/TestClass.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/TestClass.java
@@ -7,6 +7,9 @@ import io.avaje.jsonb.Json;
 @Json
 public class TestClass {
 
+  @Json.JsonAlias({"something", "something2"})
+  private String alias;
+
   private String s;
 
   private int i;
@@ -19,6 +22,13 @@ public class TestClass {
 
   private List<String> list;
 
+  public String getAlias() {
+    return alias;
+  }
+
+  public void setAlias(String alias) {
+    this.alias = alias;
+  }
 
   public String getS() {
     return s;

--- a/jsonb/src/main/java/io/avaje/jsonb/Json.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Json.java
@@ -92,6 +92,24 @@ public @interface Json {
   }
 
   /**
+   * Define one or more alternative names for a property accepted
+   * during deserialization.
+   *
+   * <pre>{@code
+   * @Json.JsonAlias("$code")
+   * String referenceCode;
+   *
+   * }</pre>
+   */
+  @Retention(CLASS)
+  @Target({ElementType.FIELD})
+  @interface JsonAlias {
+
+    /** One or more secondary names to accept as aliases to the official name. */
+    String[] value();
+  }
+
+  /**
    * Exclude the property from serialization, deserialization or both.
    * <p>
    * We can explicitly use {@code deserialize=true} to include the property in


### PR DESCRIPTION
Adds a new annotation we can use to specify alternate deserialization names.

```
@Json
@Getter
@Setter
public class TestClass {

  @Json.JsonAlias({"something", "something2"})
  private String alias;

  private String s;

  private int i;

  private Integer integer;

  private char ch;

  private Character chara;

  private List<String> list;
}
```
generated adapter fromJson looks like.
```
  @Override
  public TestClass fromJson(JsonReader reader) {
    TestClass _$testClass = new TestClass();

    // read json
    reader.beginObject();
    reader.names(names);
    while (reader.hasNextField()) {
      String fieldName = reader.nextField();
      switch (fieldName) {
        case "something":
        case "something2":
        case "alias": {
          _$testClass.setAlias(stringJsonAdapter.fromJson(reader)); break;
        }
        case "s": {
          _$testClass.setS(stringJsonAdapter.fromJson(reader)); break;
        }
        case "i": {
          _$testClass.setI(pintJsonAdapter.fromJson(reader)); break;
        }
        case "integer": {
          _$testClass.setInteger(integerJsonAdapter.fromJson(reader)); break;
        }
 and so on...
```