### PR TITLE
Lengthen Inner Type short names 

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SimpleComponentWriter.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SimpleComponentWriter.java
@@ -67,12 +67,8 @@ final class SimpleComponentWriter {
   }
 
   private String typeShortName(String adapterShortName) {
-    String typeName = adapterShortName.substring(0, adapterShortName.length() - 11);
-    int pos = typeName.lastIndexOf('$');
-    if (pos > -1) {
-      return typeName.substring(pos + 1);
-    }
-    return typeName;
+    final String typeName = adapterShortName.substring(0, adapterShortName.length() - 11);
+    return typeName.replace("$", ".");
   }
 
   private void writeClassEnd() {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
@@ -91,7 +91,13 @@ final class Util {
     if (posPrior == -1) {
       return adapterFullName.substring(posLast + 1, nameEnd);
     }
-    return adapterFullName.substring(0, posPrior)
-      + adapterFullName.substring(posLast, nameEnd).replace('$', '.');
+
+    final String className =
+        adapterFullName.substring(0, posPrior) + adapterFullName.substring(posLast, nameEnd);
+    final int $index = className.indexOf("$");
+
+    if ($index != -1) return className.substring(0, $index);
+
+    return className;
   }
 }


### PR DESCRIPTION
Change generation to use expanded short name (to avoid name conflicts when inner types have the same name)
```
public class AuthProvider  {
  @Json
  public record Oauth2Token(
      @Property("expires_in") int expiresIn,
      @Property("access_token") String value,
      @Property("token_type") String tokenType) {}
}

```
now in the GeneratedJsonComponent class, will generate like this
```
    builder.add(AuthProvider.Oauth2Token.class, AuthProvider$Oauth2TokenJsonAdapter::new);
```