### PR TITLE
Jsonb is no longer optional dependency for generators

### DIFF
--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -17,7 +17,6 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
       <version>${project.version}</version>
-      <optional>true</optional>
       <scope>provided</scope>
     </dependency>
 

--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -17,7 +17,6 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
It seems the http generators can't detect jsonb on the CP while using the mvn compiler plugin. 