### PR TITLE
Fix MetaData Reading

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
@@ -48,21 +48,15 @@ final class ComponentReader {
 
         metaData.value().stream()
             .map(TypeMirror::toString)
-            .map(this::adapterNameFromEntry)
             .forEach(componentMetaData::add);
 
       } else if (metaDataFactory != null) {
 
         metaDataFactory.value().stream()
             .map(TypeMirror::toString)
-            .map(this::adapterNameFromEntry)
             .forEach(componentMetaData::add);
       }
     }
-  }
-
-  private String adapterNameFromEntry(Object adapterEntry) {
-    return Util.trimClassSuffix(adapterEntry.toString());
   }
 
   private String loadMetaInfServices() {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
@@ -55,13 +55,6 @@ final class Util {
     return input.replaceAll("^\"|\"$", "\\\\\"");
   }
 
-  /**
-   * Trim off the .class suffix.
-   */
-  static String trimClassSuffix(String nameWithSuffix) {
-    return nameWithSuffix.substring(0, nameWithSuffix.length() - 6);
-  }
-
   static String initLower(String name) {
     StringBuilder sb = new StringBuilder(name.length());
     boolean toLower = true;


### PR DESCRIPTION
With prisms, there is no ".class" suffix to trim off, so it was butchering the Class Names instead.  Fixes #60 