### PR TITLE
Fix avaje-inject plugin to be compatible with 8.13-RC4 (Supplier)

### DIFF
--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>8.13-RC2</version>
+      <version>8.13-RC4</version>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
The prior compiled using jakarta.inject.Provider rather than Supplier. We want to use Supplier to be compatible with the javax.inject of avaje-inject.