### PR TITLE
Fix Null Enum Bug/SubType Short Name

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/enums/Staff.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/Staff.java
@@ -1,0 +1,41 @@
+package org.example.customer.enums;
+
+import java.util.Objects;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public class Staff {
+
+  private String name;
+  private StaffStatus status;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public StaffStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(StaffStatus status) {
+    this.status = status;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, status);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if ((obj == null) || (getClass() != obj.getClass())) return false;
+    final Staff other = (Staff) obj;
+    return Objects.equals(name, other.name) && status == other.status;
+  }
+}

--- a/blackbox-test/src/main/java/org/example/customer/enums/StaffStatus.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/StaffStatus.java
@@ -1,0 +1,18 @@
+package org.example.customer.enums;
+
+import io.avaje.jsonb.Json;
+
+public enum StaffStatus {
+    NORMAL(1),
+    ;
+    public final int code;
+
+    StaffStatus(int code) {
+        this.code = code;
+    }
+
+    @Json.Value
+    public int getCode() {
+        return code;
+    }
+}

--- a/blackbox-test/src/test/java/org/example/customer/enums/StaffStatusTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/enums/StaffStatusTest.java
@@ -1,0 +1,37 @@
+package org.example.customer.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+
+class StaffStatusTest {
+
+  final JsonType<Staff> jsonb = Jsonb.builder().build().type(Staff.class);
+
+  @Test
+  void null_Enum_To_From_Json() {
+    final var bean = new Staff();
+    bean.setName("ZY");
+    // bean.setStatus(...);
+    final var str = jsonb.toJson(bean);
+    assertThat(str).isEqualTo("{\"name\":\"ZY\"}");
+
+    final var staff = jsonb.fromJson(str);
+    assertThat(bean).isEqualTo(staff);
+  }
+
+  @Test
+  void enum_To_From_Json() {
+    final var bean = new Staff();
+    bean.setName("ZY");
+    bean.setStatus(StaffStatus.NORMAL);
+
+    final var str = jsonb.toJson(bean);
+    assertThat(str).isEqualTo("{\"name\":\"ZY\",\"status\":1}");
+    final var staff = jsonb.fromJson(str);
+    assertThat(bean).isEqualTo(staff);
+  }
+}

--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -10,6 +10,9 @@
   <artifactId>avaje-jsonb-generator</artifactId>
   <name>jsonb generator</name>
   <description>annotation processor generating json adapters</description>
+  <properties>
+    <avaje.prisms.version>1.6</avaje.prisms.version>
+  </properties>
 
   <dependencies>
 
@@ -22,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-prisms</artifactId>
-      <version>1.6</version>
+      <version>${avaje.prisms.version}</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
@@ -50,7 +53,7 @@
             <path>
               <groupId>io.avaje</groupId>
               <artifactId>avaje-prisms</artifactId>
-              <version>1.6</version>
+              <version>${avaje.prisms.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
@@ -26,6 +26,8 @@ final class BeanReader {
   private FieldReader unmappedField;
   private boolean hasRaw;
   private final boolean isRecord;
+  private final boolean patternMatch =
+      Float.parseFloat(System.getProperty("java.specification.version")) >= 17;
 
   BeanReader(TypeElement beanType) {
     this.beanType = beanType;
@@ -263,8 +265,12 @@ final class BeanReader {
         String subType = subTypeMeta.type();
         String subTypeName = subTypeMeta.name();
         String elseIf = i == 0 ? "if" : "else if";
-        writer.append("    %s (%s instanceof %s) {", elseIf, varName, subType).eol();
-        writer.append("      %s sub = (%s)%s;", subType, subType, varName).eol();
+        if (patternMatch) {
+          writer.append("    %s (%s instanceof final %s sub) {", elseIf, varName, subType).eol();
+        } else {
+          writer.append("    %s (%s instanceof %s) {", elseIf, varName, subType).eol();
+          writer.append("      %s sub = (%s)%s;", subType, subType, varName).eol();
+        }
         writer.append("      writer.name(0);").eol();
         writer.append("      stringJsonAdapter.toJson(writer, \"%s\");", subTypeName).eol();
         writeToJsonForType(writer, "sub", "      ", subType);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
@@ -26,7 +26,7 @@ final class BeanReader {
   private FieldReader unmappedField;
   private boolean hasRaw;
   private final boolean isRecord;
-  private final boolean patternMatch =
+  private static final boolean PATTERN_MATCH =
       Float.parseFloat(System.getProperty("java.specification.version")) >= 17;
 
   BeanReader(TypeElement beanType) {
@@ -265,7 +265,7 @@ final class BeanReader {
         String subType = subTypeMeta.type();
         String subTypeName = subTypeMeta.name();
         String elseIf = i == 0 ? "if" : "else if";
-        if (patternMatch) {
+        if (PATTERN_MATCH) {
           writer.append("    %s (%s instanceof final %s sub) {", elseIf, varName, subType).eol();
         } else {
           writer.append("    %s (%s instanceof %s) {", elseIf, varName, subType).eol();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
@@ -43,7 +43,8 @@ final class BeanReader {
     this.hasSubTypes = typeReader.hasSubTypes();
     this.allFields = typeReader.allFields();
     this.constructor = typeReader.constructor();
-    this.isRecord = isRecord(beanType);
+    this.isRecord = isRecord(beanType); 
+    typeReader.subTypes().stream().map(TypeSubTypeMeta::type).forEach(importTypes::add);
   }
 
   public BeanReader(TypeElement beanType, TypeElement mixInElement) {
@@ -61,6 +62,7 @@ final class BeanReader {
     this.allFields = typeReader.allFields();
     this.constructor = typeReader.constructor();
     this.isRecord = isRecord(beanType);
+    typeReader.subTypes().stream().map(TypeSubTypeMeta::type).forEach(importTypes::add);
   }
 
   @SuppressWarnings("unchecked")
@@ -265,11 +267,12 @@ final class BeanReader {
         String subType = subTypeMeta.type();
         String subTypeName = subTypeMeta.name();
         String elseIf = i == 0 ? "if" : "else if";
+        final String subTypeShort = Util.shortType(subTypeMeta.type());
         if (PATTERN_MATCH) {
-          writer.append("    %s (%s instanceof final %s sub) {", elseIf, varName, subType).eol();
+          writer.append("    %s (%s instanceof final %s sub) {", elseIf, varName, subTypeShort).eol();
         } else {
-          writer.append("    %s (%s instanceof %s) {", elseIf, varName, subType).eol();
-          writer.append("      %s sub = (%s)%s;", subType, subType, varName).eol();
+          writer.append("    %s (%s instanceof %s) {", elseIf, varName, subTypeShort).eol();
+          writer.append("      %s sub = (%s) %s;", subType, subTypeShort, varName).eol();
         }
         writer.append("      writer.name(0);").eol();
         writer.append("      stringJsonAdapter.toJson(writer, \"%s\");", subTypeName).eol();
@@ -348,7 +351,7 @@ final class BeanReader {
 
   private void writeFromJsonWithSubTypes(Append writer, String varName) {
     writer.append("    if (type == null) {").eol();
-    writer.append("      throw new IllegalStateException(\"Missing %s property which is required?\");", typeProperty).eol();
+    writer.append("      throw new IllegalStateException(\"Missing Required %s property that determines deserialization type\");", typeProperty).eol();
     writer.append("    }").eol();
     for (TypeSubTypeMeta subTypeMeta : typeReader.subTypes()) {
       subTypeMeta.writeFromJsonBuild(writer, varName, this);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeSubTypeMeta.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeSubTypeMeta.java
@@ -7,6 +7,7 @@ final class TypeSubTypeMeta {
 
   private final String type;
   private String name;
+  private final String shortType;
   private TypeElement typeElement;
   private boolean defaultPublicConstructor;
   private final List<MethodReader> publicConstructors = new ArrayList<>();
@@ -19,6 +20,7 @@ final class TypeSubTypeMeta {
   TypeSubTypeMeta(SubTypePrism prism) {
     type = prism.type().toString();
     name = Util.escapeQuotes(prism.name());
+    shortType = Util.shortType(type);
   }
 
   void setElement(TypeElement element) {
@@ -35,7 +37,7 @@ final class TypeSubTypeMeta {
 
   String name() {
     if (name.isBlank()) {
-      name = Util.shortName(type);
+      name = Util.shortType(type);
     }
     return name;
   }
@@ -72,7 +74,8 @@ final class TypeSubTypeMeta {
   private final Set<String> constructorFieldNames = new LinkedHashSet<>();
 
   private void writeFromJsonConstructor(Append writer, String varName, BeanReader beanReader) {
-    writer.append("      %s _$%s = new %s(", type, varName, type);
+    
+	writer.append("      %s _$%s = new %s(", shortType, varName, shortType);
     MethodReader constructor = findConstructor();
     if (constructor != null) {
       List<MethodReader.MethodParam> params = constructor.getParams();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
@@ -20,6 +20,25 @@ final class Util {
     }
   }
 
+  static String shortType(String fullType) {
+    int p = fullType.lastIndexOf('.');
+    if (p == -1) {
+      return fullType;
+    } else if (fullType.startsWith("java")) {
+      return fullType.substring(p + 1);
+    } else {
+      var result = "";
+      var foundClass = false;
+      for (final String part : fullType.split("\\.")) {
+        if (foundClass || Character.isUpperCase(part.charAt(0))) {
+          foundClass = true;
+          result += (result.isEmpty() ? "" : ".") + part;
+        }
+      }
+      return result;
+    }
+  }
+
   /**
    * Return the common parent package.
    */

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -385,16 +385,17 @@ final class BasicTypeAdapters {
   static class EnumValueMap<T extends Enum<T>> extends JsonAdapter<T> {
 
     private final Class<T> enumType;
-    private final Map<String, String> toValue = new HashMap<>();
-    private final Map<String, String> toName = new HashMap<>();
+    private final Map<T, String> toValue;
+    private final Map<String, T> toEnum = new HashMap<>();
 
     EnumValueMap(Method method, Class<T> enumType) {
       this.enumType = enumType;
-      for (Enum<?> enumConstant : enumType.getEnumConstants()) {
+      this.toValue = new EnumMap<>(enumType);
+      for (var enumConstant : enumType.getEnumConstants()) {
         try {
           String val = String.valueOf(method.invoke(enumConstant));
-          toValue.put(enumConstant.name(), val);
-          toName.put(val, enumConstant.name());
+          toValue.put(enumConstant, val);
+          toEnum.put(val, enumConstant);
         } catch (Exception e) {
           throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
         }
@@ -403,17 +404,17 @@ final class BasicTypeAdapters {
 
     @Override
     public void toJson(JsonWriter writer, T value) {
-      writer.value(toValue.get(value.name()));
+      writer.value(toValue.get(value));
     }
 
     @Override
     public T fromJson(JsonReader reader) {
       String value = reader.readString();
-      String name = toName.get(value);
-      if (name == null) {
+      var enumConstant = toEnum.get(value);
+      if (enumConstant == null) {
         throw new JsonDataException("Unable to determine enum value " + enumType + " value for " + value + " at " + reader.location());
       }
-      return Enum.valueOf(enumType, name);
+      return enumConstant;
     }
 
     @Override
@@ -425,16 +426,17 @@ final class BasicTypeAdapters {
   static class EnumIntValueMap<T extends Enum<T>> extends JsonAdapter<T> {
 
     private final Class<T> enumType;
-    private final Map<String, Integer> toValue = new HashMap<>();
-    private final Map<Integer, String> toName = new HashMap<>();
+    private final Map<T, Integer> toValue;
+    private final Map<Integer, T> toEnum = new HashMap<>();
 
     EnumIntValueMap(Method method, Class<T> enumType) {
       this.enumType = enumType;
-      for (Enum<?> enumConstant : enumType.getEnumConstants()) {
+      this.toValue = new EnumMap<>(enumType);
+      for (var enumConstant : enumType.getEnumConstants()) {
         try {
           Integer val = (Integer) method.invoke(enumConstant);
-          toValue.put(enumConstant.name(), val);
-          toName.put(val, enumConstant.name());
+          toValue.put(enumConstant, val);
+          toEnum.put(val, enumConstant);
         } catch (Exception e) {
           throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
         }
@@ -443,18 +445,17 @@ final class BasicTypeAdapters {
 
     @Override
     public void toJson(JsonWriter writer, T value) {
-      int val = toValue.get(value.name());
-      writer.value(val);
+      writer.value(toValue.get(value));
     }
 
     @Override
     public T fromJson(JsonReader reader) {
       int value = reader.readInt();
-      String name = toName.get(value);
-      if (name == null) {
+      var enumConstant = toEnum.get(value);
+      if (enumConstant == null) {
         throw new JsonDataException("Unable to determine enum value " + enumType + " value for " + value + " at " + reader.location());
       }
-      return Enum.valueOf(enumType, name);
+      return enumConstant;
     }
 
     @Override

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -369,16 +369,16 @@ final class BasicTypeAdapters {
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static JsonAdapter<?> enumMap(Class<?> type, Method method) {
     final Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>) type;
-    if (type == int.class) {
+    final var returnType = method.getReturnType();
+    if (returnType == int.class) {
       return new EnumIntValueMap(method, enumType);
-    } else if (type == boolean.class) {
+    } else if (returnType == boolean.class) {
 
       return new EnumBoolValueMap(method, enumType);
-    } else if (type == long.class) {
+    } else if (returnType == long.class) {
 
       return new EnumLongValueMap(method, enumType);
-    } else if (type == double.class) {
-
+    } else if (returnType == double.class) {
       return new EnumDoubleValueMap(method, enumType);
     } else {
       return new EnumValueMap(method, enumType);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -370,13 +370,12 @@ final class BasicTypeAdapters {
   private static JsonAdapter<?> enumMap(Class<?> type, Method method) {
     final Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>) type;
     final var returnType = method.getReturnType();
+    
     if (returnType == int.class) {
       return new EnumIntValueMap(method, enumType);
     } else if (returnType == boolean.class) {
-
       return new EnumBoolValueMap(method, enumType);
     } else if (returnType == long.class) {
-
       return new EnumLongValueMap(method, enumType);
     } else if (returnType == double.class) {
       return new EnumDoubleValueMap(method, enumType);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -368,35 +368,37 @@ final class BasicTypeAdapters {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   private static JsonAdapter<?> enumMap(Class<?> type, Method method) {
-    Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>) type;
-    EnumType enumType1 = determineEnumType(method.getReturnType());
-    if (enumType1 == EnumType.INT) {
+    final Class<? extends Enum<?>> enumType = (Class<? extends Enum<?>>) type;
+    if (type == int.class) {
       return new EnumIntValueMap(method, enumType);
+    } else if (type == boolean.class) {
+
+      return new EnumBoolValueMap(method, enumType);
+    } else if (type == long.class) {
+
+      return new EnumLongValueMap(method, enumType);
+    } else if (type == double.class) {
+
+      return new EnumDoubleValueMap(method, enumType);
+    } else {
+      return new EnumValueMap(method, enumType);
     }
-    return new EnumValueMap(method, enumType);
   }
 
-  enum EnumType {INT, STRING}
+  static class EnumValueMap<T extends Enum<T>> extends EnumJsonAdapter<T> {
 
-  private static EnumType determineEnumType(Class<?> returnType) {
-    return returnType == int.class ? EnumType.INT : EnumType.STRING;
-  }
-
-  static class EnumValueMap<T extends Enum<T>> extends JsonAdapter<T> {
-
-    private final Class<T> enumType;
     private final Map<T, String> toValue;
     private final Map<String, T> toEnum = new HashMap<>();
 
     EnumValueMap(Method method, Class<T> enumType) {
-      this.enumType = enumType;
+      super(enumType);
       this.toValue = new EnumMap<>(enumType);
-      for (var enumConstant : enumType.getEnumConstants()) {
+      for (final var enumConstant : enumType.getEnumConstants()) {
         try {
-          String val = String.valueOf(method.invoke(enumConstant));
+          final var val = String.valueOf(method.invoke(enumConstant));
           toValue.put(enumConstant, val);
           toEnum.put(val, enumConstant);
-        } catch (Exception e) {
+        } catch (final Exception e) {
           throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
         }
       }
@@ -409,35 +411,29 @@ final class BasicTypeAdapters {
 
     @Override
     public T fromJson(JsonReader reader) {
-      String value = reader.readString();
-      var enumConstant = toEnum.get(value);
+      final String value = reader.readString();
+      final var enumConstant = toEnum.get(value);
       if (enumConstant == null) {
-        throw new JsonDataException("Unable to determine enum value " + enumType + " value for " + value + " at " + reader.location());
+        throwException(value, reader.location());
       }
       return enumConstant;
     }
-
-    @Override
-    public String toString() {
-      return "JsonAdapter(" + this.enumType.getName() + ")";
-    }
   }
 
-  static class EnumIntValueMap<T extends Enum<T>> extends JsonAdapter<T> {
+  static class EnumIntValueMap<T extends Enum<T>> extends EnumJsonAdapter<T> {
 
-    private final Class<T> enumType;
     private final Map<T, Integer> toValue;
     private final Map<Integer, T> toEnum = new HashMap<>();
 
     EnumIntValueMap(Method method, Class<T> enumType) {
-      this.enumType = enumType;
+      super(enumType);
       this.toValue = new EnumMap<>(enumType);
-      for (var enumConstant : enumType.getEnumConstants()) {
+      for (final var enumConstant : enumType.getEnumConstants()) {
         try {
-          Integer val = (Integer) method.invoke(enumConstant);
+          final Integer val = (Integer) method.invoke(enumConstant);
           toValue.put(enumConstant, val);
           toEnum.put(val, enumConstant);
-        } catch (Exception e) {
+        } catch (final Exception e) {
           throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
         }
       }
@@ -450,22 +446,135 @@ final class BasicTypeAdapters {
 
     @Override
     public T fromJson(JsonReader reader) {
-      int value = reader.readInt();
-      var enumConstant = toEnum.get(value);
+      final int value = reader.readInt();
+      final var enumConstant = toEnum.get(value);
       if (enumConstant == null) {
-        throw new JsonDataException("Unable to determine enum value " + enumType + " value for " + value + " at " + reader.location());
+        throwException(value, reader.location());
       }
       return enumConstant;
     }
+  }
+
+  static class EnumDoubleValueMap<T extends Enum<T>> extends EnumJsonAdapter<T> {
+
+    private final Map<T, Double> toValue;
+    private final Map<Double, T> toEnum = new HashMap<>();
+
+    EnumDoubleValueMap(Method method, Class<T> enumType) {
+      super(enumType);
+      this.toValue = new EnumMap<>(enumType);
+      for (final var enumConstant : enumType.getEnumConstants()) {
+        try {
+          final Double val = (Double) method.invoke(enumConstant);
+          toValue.put(enumConstant, val);
+          toEnum.put(val, enumConstant);
+        } catch (final Exception e) {
+          throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
+        }
+      }
+    }
 
     @Override
-    public String toString() {
-      return "JsonAdapter(" + this.enumType.getName() + ")";
+    public void toJson(JsonWriter writer, T value) {
+      writer.value(toValue.get(value));
+    }
+
+    @Override
+    public T fromJson(JsonReader reader) {
+      final var value = reader.readDouble();
+      final var enumConstant = toEnum.get(value);
+      if (enumConstant == null) {
+        throwException(value, reader.location());
+      }
+      return enumConstant;
     }
   }
 
-  static final class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
-    private final Class<T> enumType;
+  static final class EnumLongValueMap<T extends Enum<T>> extends EnumJsonAdapter<T> {
+
+    private final Map<T, Long> toValue;
+    private final Map<Long, T> toEnum = new HashMap<>();
+
+    EnumLongValueMap(Method method, Class<T> enumType) {
+      super(enumType);
+      this.toValue = new EnumMap<>(enumType);
+      for (final var enumConstant : enumType.getEnumConstants()) {
+        try {
+          final var val = (Long) method.invoke(enumConstant);
+          toValue.put(enumConstant, val);
+          toEnum.put(val, enumConstant);
+        } catch (final Exception e) {
+          throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
+        }
+      }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, T value) {
+      writer.value(toValue.get(value));
+    }
+
+    @Override
+    public T fromJson(JsonReader reader) {
+      final var value = reader.readLong();
+      final var enumConstant = toEnum.get(value);
+      if (enumConstant == null) {
+        throwException(value, reader.location());
+      }
+      return enumConstant;
+    }
+  }
+
+  static final class EnumBoolValueMap<T extends Enum<T>> extends EnumJsonAdapter<T> {
+
+    private T trueEnum = null;
+    private T falseEnum = null;
+
+    EnumBoolValueMap(Method method, Class<T> enumType) {
+      super(enumType);
+      for (final var enumConstant : enumType.getEnumConstants()) {
+        try {
+          final boolean val = (boolean) method.invoke(enumConstant);
+          if (val) {
+            trueEnum = enumConstant;
+          } else {
+            falseEnum = enumConstant;
+          }
+        } catch (final Exception e) {
+          throw new JsonException("Error trying to invoke Json.Value method on " + enumConstant, e);
+        }
+      }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, T value) {
+
+      if (value == null) {
+        writer.value((Boolean) null);
+      } else if (value == trueEnum) {
+        writer.value(true);
+      } else {
+        writer.value(false);
+      }
+    }
+
+    @Override
+    public T fromJson(JsonReader reader) {
+      final boolean value = reader.readBoolean();
+      T enumConstant;
+
+      if (value) {
+        enumConstant = trueEnum;
+      } else {
+        enumConstant = falseEnum;
+      }
+      return enumConstant;
+    }
+  }
+
+  static class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
+
+    protected final Class<T> enumType;
 
     EnumJsonAdapter(Class<T> enumType) {
       this.enumType = enumType;
@@ -473,13 +582,22 @@ final class BasicTypeAdapters {
 
     @Override
     public T fromJson(JsonReader reader) {
-      String value = reader.readString();
+      final String value = reader.readString();
       return Enum.valueOf(enumType, value);
     }
 
     @Override
     public void toJson(JsonWriter writer, T value) {
-      writer.value(value.name());
+      if (value != null) {
+        writer.value(value.name());
+      } else {
+        writer.value((String) null);
+      }
+    }
+
+    protected final void throwException(Object value, String location) {
+      throw new JsonDataException(
+          "Unable to determine enum value " + enumType + " value for " + value + " at " + location);
     }
 
     @Override


### PR DESCRIPTION
I remembered `EnumMap` was a thing, so used that to fix the issue. Fixes #77 

- converts `toValue` to use EnumMap instead of HashMap to get enum value. 
- converts `toValue` to be a `Map<Object, T>` to get enum type
- support long, double, and boolean enum value.
- on JDK17, use `instanceof` pattern matching for subtype
- use short names for subtype