### PR TITLE
Serialize empty Collections by default/Use Enum TypeProperty for SubTypes (Part 1)

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/subtype/Animal.java
+++ b/blackbox-test/src/main/java/org/example/customer/subtype/Animal.java
@@ -9,4 +9,9 @@ import io.avaje.jsonb.Json;
 public interface Animal {
 
   String name();
+  enum AnimalEnum{
+	  Cat,
+	  Dog,
+	  Fish
+  }
 }

--- a/blackbox-test/src/main/java/org/example/customer/subtype/Cat.java
+++ b/blackbox-test/src/main/java/org/example/customer/subtype/Cat.java
@@ -2,17 +2,15 @@ package org.example.customer.subtype;
 
 public class Cat implements Animal {
 
-
-  private String dtype;
-
   private String name;
 
+  private AnimalEnum dtype;
 
-  public String dtype() {
+  public AnimalEnum dtype() {
     return dtype;
   }
 
-  public void dtype(String dtype) {
+  public void dtype(AnimalEnum dtype) {
     this.dtype = dtype;
   }
 

--- a/blackbox-test/src/test/java/org/example/JsonIgnoreTest.java
+++ b/blackbox-test/src/test/java/org/example/JsonIgnoreTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonIgnoreTest {
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
   JsonType<Customer> jsonType = jsonb.type(Customer.class);
 
   @Test

--- a/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
@@ -15,7 +15,7 @@ class CustomerTest {
 
   final String jsonStart = "{\"id\":42,\"name\":\"rob\",\"status\":\"ACTIVE\",\"whenCreated\":";
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
 
   @Test
   void anyToJson() {

--- a/blackbox-test/src/test/java/org/example/customer/SomeAddressWrapperTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/SomeAddressWrapperTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SomeAddressWrapperTest {
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
 
   @Test
   void test_when_null() {
@@ -45,7 +45,7 @@ class SomeAddressWrapperTest {
   @Test
   void includeNull_viaJsonB() {
 
-    Jsonb jsonb = Jsonb.builder().serializeNulls(true).build();
+    Jsonb jsonb = Jsonb.builder().serializeNulls(true).serializeEmpty(false).build();
 
     var type = jsonb.type(SomeAddressWrapper.class);
     String asJson = type.toJson(new SomeAddressWrapper(43L, null, Collections.emptyList()));

--- a/blackbox-test/src/test/java/org/example/customer/cascade/MCTopTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/cascade/MCTopTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MCTopTest {
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
 
   @Test
   void toJson() {

--- a/blackbox-test/src/test/java/org/example/customer/subtype/AnimalTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/subtype/AnimalTest.java
@@ -22,7 +22,7 @@ class AnimalTest {
     Animal animal = animalJsonType.fromJson(asJson);
     assertThat(animal).isInstanceOf(Cat.class);
     Cat cat1 = (Cat) animal;
-    assertThat(cat1.dtype()).isEqualTo("Cat");
+    assertThat(cat1.dtype().toString()).isEqualTo("Cat");
     cat1.dtype(null);
     assertThat(cat1.name()).isEqualTo("PussInBoots");
   }

--- a/blackbox-test/src/test/java/org/example/customer/views/ViewTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/views/ViewTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ViewTest {
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
 
   @Test
   void jsonView_sameInstance() {

--- a/blackbox-test/src/test/java/org/example/other/place/MyOtherClassTest.java
+++ b/blackbox-test/src/test/java/org/example/other/place/MyOtherClassTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MyOtherClassTest {
 
-  Jsonb jsonb = Jsonb.builder().build();
+  Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
   JsonType<MyOtherClass> jsonType = jsonb.type(MyOtherClass.class);
 
   @Test

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/BeanReader.java
@@ -191,16 +191,16 @@ final class BeanReader {
     }
     final StringBuilder builder = new StringBuilder();
     for (int i = 0, size = allFields.size(); i < size; i++) {
-      final FieldReader fieldReader = allFields.get(i);
-      if (usesTypeProperty && fieldReader.propertyName().equals(typePropertyKey())) {
-        builder.append(" ");
-        continue;
+        final FieldReader fieldReader = allFields.get(i);
+        if (i > 0) {
+          builder.append(", ");
+        }
+        if (usesTypeProperty && fieldReader.propertyName().equals(typePropertyKey())) {
+          builder.append(" ");
+          continue;
+        }
+        builder.append("\"").append(fieldReader.propertyName()).append("\"");
       }
-      if (i > 0) {
-        builder.append(", ");
-      }
-      builder.append("\"").append(fieldReader.propertyName()).append("\"");
-    }
     writer.append(builder.toString().replace(" , ", ""));
     writer.append(");").eol();
   }
@@ -357,7 +357,7 @@ final class BeanReader {
 
     final var useSwitch = typeReader.subTypes().size() >= 3;
     if (useSwitch) {
-      writer.append("    switch (%s) {", typeVar).eol();
+      writer.append("    switch (%s) {", usesTypeProperty ? typeVar + ".toString()" : typeVar).eol();
     }
 
     for (final TypeSubTypeMeta subTypeMeta : typeReader.subTypes()) {

--- a/jsonb-jackson/src/test/java/org/example/CustomerTest.java
+++ b/jsonb-jackson/src/test/java/org/example/CustomerTest.java
@@ -15,7 +15,7 @@ class CustomerTest {
 
   final String jsonStart = "{\"id\":42,\"name\":\"rob\",\"whenCreated\":";
 
-  Jsonb jsonb = Jsonb.builder().add(new MyComponent()).build();
+  Jsonb jsonb = Jsonb.builder().add(new MyComponent()).serializeEmpty(false).build();
 
   @Test
   void toJson() {

--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -358,7 +358,7 @@ public interface Jsonb {
     /**
      * Set to serialise empty collections or not.
      * <p>
-     * Default is to not serialise empty collections.
+     * Default is to serialize empty collections.
      */
     Builder serializeEmpty(boolean serializeEmpty);
 

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -211,7 +211,7 @@ final class DJsonb implements Jsonb {
     private boolean failOnUnknown;
     private boolean mathTypesAsString;
     private boolean serializeNulls;
-    private boolean serializeEmpty;
+    private boolean serializeEmpty = true;
     private JsonStreamAdapter adapter;
 
     @Override


### PR DESCRIPTION
empty != null, so I can't really think of a situation where you wouldn't want to serialize an empty array. People have been tripped up by this and I expect this to become a recurring question. Why not just make it an opt-in feature

I also know a guy that uses an enum as his type property, he kinda needs this fast.`toString` works for now, but will add a proper enum switch logic later.


- serialize empty collections by default
-  fix bug where property names were missing a comma
- now if you define an enum type property it will be used in the `fromJson` subtype switch