### PR TITLE
Add Default `java.util.Date` Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Fast, reflection-free Json binding via apt source code generation. A light (~188
 - Constructors and accessors/getters/setters of any style "just work" (records, constructors, 'fluid setters')
 - Jackson-like annotations: `@Json.Raw`, `@Json.Property`, `@Json.Ignore`, `@Json.Alias`, etc.
 - Support Mixins (adding jsonb features to types we can't directly annotate).
+- Supports Generic Types.
 - Provides support for dynamic json views (similar in style to that presented by [LinkedIn at java one in 2009](https://www.slideshare.net/linkedin/building-consistent-restful-apis-in-a-highperformance-environment)
 
 ### Built-in Type Adapters

--- a/jsonb/src/main/java/io/avaje/jsonb/core/JavaTimeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/JavaTimeAdapters.java
@@ -1,5 +1,6 @@
 package io.avaje.jsonb.core;
 
+import java.util.Date;
 import io.avaje.jsonb.JsonAdapter;
 import io.avaje.jsonb.JsonReader;
 import io.avaje.jsonb.JsonWriter;
@@ -25,13 +26,34 @@ final class JavaTimeAdapters {
     if (type == ZonedDateTime.class) return JavaTimeAdapters.ZONED_DATE_TIME_ADAPTER.nullSafe();
     if (type == ZoneId.class) return JavaTimeAdapters.ZONE_ID_ADAPTER.nullSafe();
     if (type == ZoneOffset.class) return JavaTimeAdapters.ZONE_OFFSET_ADAPTER.nullSafe();
-    return null;
+	if (type == Date.class) return JavaTimeAdapters.UTIL_DATE.nullSafe();
+
+	return null;
   };
 
   /**
    * Using ISO-8601
    */
-  private static final JsonAdapter<Instant> INSTANT_ADAPTER = new JsonAdapter<Instant>() {
+
+  private static final JsonAdapter<Date> UTIL_DATE =
+	      new JsonAdapter<>() {
+	        @Override
+	        public Date fromJson(JsonReader reader) {
+	          return Date.from(Instant.parse(reader.readString()));
+	        }
+
+	        @Override
+	        public void toJson(JsonWriter writer, Date value) {
+	          writer.value(value.toInstant().toString());
+	        }
+
+	        @Override
+	        public String toString() {
+	          return "JsonAdapter(Date)";
+	        }
+	      };
+
+  private static final JsonAdapter<Instant> INSTANT_ADAPTER = new JsonAdapter<>() {
     @Override
     public Instant fromJson(JsonReader reader) {
       return Instant.parse(reader.readString());
@@ -48,7 +70,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<OffsetDateTime> OFFSET_DATE_TIME_ADAPTER = new JsonAdapter<OffsetDateTime>() {
+  private static final JsonAdapter<OffsetDateTime> OFFSET_DATE_TIME_ADAPTER = new JsonAdapter<>() {
     @Override
     public OffsetDateTime fromJson(JsonReader reader) {
       return OffsetDateTime.parse(reader.readString());
@@ -65,7 +87,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<OffsetTime> OFFSET_TIME_ADAPTER = new JsonAdapter<OffsetTime>() {
+  private static final JsonAdapter<OffsetTime> OFFSET_TIME_ADAPTER = new JsonAdapter<>() {
     @Override
     public OffsetTime fromJson(JsonReader reader) {
       return OffsetTime.parse(reader.readString());
@@ -82,7 +104,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<ZonedDateTime> ZONED_DATE_TIME_ADAPTER = new JsonAdapter<ZonedDateTime>() {
+  private static final JsonAdapter<ZonedDateTime> ZONED_DATE_TIME_ADAPTER = new JsonAdapter<>() {
     @Override
     public ZonedDateTime fromJson(JsonReader reader) {
       return ZonedDateTime.parse(reader.readString());
@@ -99,7 +121,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<ZoneOffset> ZONE_OFFSET_ADAPTER = new JsonAdapter<ZoneOffset>() {
+  private static final JsonAdapter<ZoneOffset> ZONE_OFFSET_ADAPTER = new JsonAdapter<>() {
     @Override
     public ZoneOffset fromJson(JsonReader reader) {
       return ZoneOffset.of(reader.readString());
@@ -116,7 +138,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<ZoneId> ZONE_ID_ADAPTER = new JsonAdapter<ZoneId>() {
+  private static final JsonAdapter<ZoneId> ZONE_ID_ADAPTER = new JsonAdapter<>() {
     @Override
     public ZoneId fromJson(JsonReader reader) {
       return ZoneId.of(reader.readString());
@@ -133,7 +155,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<LocalDate> LOCAL_DATE_ADAPTER = new JsonAdapter<LocalDate>() {
+  private static final JsonAdapter<LocalDate> LOCAL_DATE_ADAPTER = new JsonAdapter<>() {
     @Override
     public LocalDate fromJson(JsonReader reader) {
       return LocalDate.parse(reader.readString());
@@ -150,7 +172,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<LocalDateTime> LOCAL_DATE_TIME_ADAPTER = new JsonAdapter<LocalDateTime>() {
+  private static final JsonAdapter<LocalDateTime> LOCAL_DATE_TIME_ADAPTER = new JsonAdapter<>() {
     @Override
     public LocalDateTime fromJson(JsonReader reader) {
       return LocalDateTime.parse(reader.readString());
@@ -167,7 +189,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<LocalTime> LOCAL_TIME_ADAPTER = new JsonAdapter<LocalTime>() {
+  private static final JsonAdapter<LocalTime> LOCAL_TIME_ADAPTER = new JsonAdapter<>() {
     @Override
     public LocalTime fromJson(JsonReader reader) {
       return LocalTime.parse(reader.readString());
@@ -184,7 +206,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<MonthDay> MONTH_DAY_ADAPTER = new JsonAdapter<MonthDay>() {
+  private static final JsonAdapter<MonthDay> MONTH_DAY_ADAPTER = new JsonAdapter<>() {
     @Override
     public MonthDay fromJson(JsonReader reader) {
       return MonthDay.parse(reader.readString());
@@ -202,7 +224,7 @@ final class JavaTimeAdapters {
   };
 
 
-  private static final JsonAdapter<Period> PERIOD_ADAPTER = new JsonAdapter<Period>() {
+  private static final JsonAdapter<Period> PERIOD_ADAPTER = new JsonAdapter<>() {
     @Override
     public Period fromJson(JsonReader reader) {
       return Period.parse(reader.readString());
@@ -219,7 +241,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<Year> YEAR_ADAPTER = new JsonAdapter<Year>() {
+  private static final JsonAdapter<Year> YEAR_ADAPTER = new JsonAdapter<>() {
     @Override
     public Year fromJson(JsonReader reader) {
       return Year.of(reader.readInt());
@@ -236,7 +258,7 @@ final class JavaTimeAdapters {
     }
   };
 
-  private static final JsonAdapter<YearMonth> YEAR_MONTH_ADAPTER = new JsonAdapter<YearMonth>() {
+  private static final JsonAdapter<YearMonth> YEAR_MONTH_ADAPTER = new JsonAdapter<>() {
     @Override
     public YearMonth fromJson(JsonReader reader) {
       return YearMonth.parse(reader.readString());


### PR DESCRIPTION
People really shouldn't be using it, but the reality is that this is still being used all over the place. Will serialize/deserialize as ISO timestamp.