### PR TITLE
Add Spring Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,21 @@ Built-in support for reading and writing Java’s core data types:
 
 # Quick Start
 
-## Step 1 - Add dependency
+## Step 1 - Add dependencies
 ```xml
 <dependency>
   <groupId>io.avaje</groupId>
   <artifactId>avaje-jsonb</artifactId>
   <version>${avaje-jsonb-version}</version>
 </dependency>
+<!-- if using spring web, add the below to use jsonb for http messaging
+<dependency>
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-jsonb-spring-starter</artifactId>
+  <version>${avaje-jsonb-version}</version>
+</dependency>
 ```
+
 And add avaje-jsonb-generator as a annotation processor
 ```xml
 
@@ -48,27 +55,6 @@ And add avaje-jsonb-generator as a annotation processor
   <version>${avaje.jsonb.version}</version>
   <scope>provided</scope>
 </dependency>
-```
-NOTE: If you have another annotation processor defined in the maven compiler plugin you will need to add it there.
-```xml
-<build>
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-compiler-plugin</artifactId>
-      <version>${maven-compiler-plugin.version}</version>
-      <configuration>
-        <annotationProcessorPaths>
-          <path>
-            <groupId>io.avaje</groupId>
-            <artifactId>avaje-jsonb-generator</artifactId>
-            <version>${avaje-jsonb-version}</version>
-          </path>
-        </annotationProcessorPaths>
-      </configuration>
-    </plugin>
-  </plugins>
-</build>
 ```
 
 ## Step 2 - Add `@Json`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built-in support for reading and writing Java’s core data types:
   <artifactId>avaje-jsonb</artifactId>
   <version>${avaje-jsonb-version}</version>
 </dependency>
-<!-- if using spring web, add the below to use jsonb for http messaging
+<!-- if using spring web, add the below to use jsonb for http messaging -->
 <dependency>
   <groupId>io.avaje</groupId>
   <artifactId>avaje-jsonb-spring-starter</artifactId>

--- a/jsonb-spring-adapter/pom.xml
+++ b/jsonb-spring-adapter/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>avaje-jsonb-parent</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>1.4-RC6</version>
+  </parent>
+
+  <artifactId>avaje-jsonb-spring-starter</artifactId>
+  <name>jsonb-spring-adapter</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>3.0.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.micrometer</groupId>
+          <artifactId>micrometer-observation</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-aop</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonBAutoConfiguration.java
+++ b/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonBAutoConfiguration.java
@@ -1,0 +1,28 @@
+package io.avaje.jsonb.spring;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.avaje.jsonb.Jsonb;
+
+@Configuration
+public class JsonBAutoConfiguration {
+
+  @Bean
+  @ConditionalOnMissingBean
+  Jsonb jsonb(
+      @Value("${jsonb.deserialize.failOnUnknown:false}") boolean failUnknown,
+      @Value("${jsonb.serialize.mathTypesAsString:false}") boolean mathTypesAsString,
+      @Value("${jsonb.serialize.empty:true}") boolean serializeEmpty,
+      @Value("${jsonb.serialize.nulls:false}") boolean serializeNulls) {
+
+    return Jsonb.builder()
+        .failOnUnknown(failUnknown)
+        .mathTypesAsString(mathTypesAsString)
+        .serializeEmpty(serializeEmpty)
+        .serializeNulls(serializeNulls)
+        .build();
+  }
+}

--- a/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbHttpConverterAutoConfiguration.java
+++ b/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbHttpConverterAutoConfiguration.java
@@ -8,7 +8,7 @@ import io.avaje.jsonb.Jsonb;
 
 @Configuration
 @ConditionalOnClass(name = "org.springframework.http.converter.GenericHttpMessageConverter")
-public class JsonbMVCAutoConfiguration {
+public class JsonbHttpConverterAutoConfiguration {
 
   @Bean
   JsonbHttpMessageConverter jsonbConverter(Jsonb jsonb) {

--- a/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbHttpMessageConverter.java
+++ b/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbHttpMessageConverter.java
@@ -1,0 +1,44 @@
+package io.avaje.jsonb.spring;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
+import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import io.avaje.jsonb.Jsonb;
+
+public class JsonbHttpMessageConverter extends AbstractGenericHttpMessageConverter<Object>
+    implements GenericHttpMessageConverter<Object> {
+
+  private final Jsonb serializer;
+
+  public JsonbHttpMessageConverter(Jsonb serializer) {
+    super(MediaType.APPLICATION_JSON);
+    this.serializer = serializer;
+  }
+
+  @Override
+  protected Object readInternal(Class<?> clazz, HttpInputMessage inputMessage)
+      throws IOException, HttpMessageNotReadableException {
+    return serializer.type(clazz).fromJson(inputMessage.getBody());
+  }
+
+  @Override
+  public Object read(Type type, Class<?> contextClass, HttpInputMessage inputMessage)
+      throws IOException, HttpMessageNotReadableException {
+
+    return serializer.type(type).fromJson(inputMessage.getBody());
+  }
+
+  @Override
+  protected void writeInternal(Object instance, Type type, HttpOutputMessage outputMessage)
+      throws IOException, HttpMessageNotWritableException {
+    serializer.type(type).toJson(instance, outputMessage.getBody());
+  }
+}

--- a/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbMVCAutoConfiguration.java
+++ b/jsonb-spring-adapter/src/main/java/io/avaje/jsonb/spring/JsonbMVCAutoConfiguration.java
@@ -1,0 +1,17 @@
+package io.avaje.jsonb.spring;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.avaje.jsonb.Jsonb;
+
+@Configuration
+@ConditionalOnClass(name = "org.springframework.http.converter.GenericHttpMessageConverter")
+public class JsonbMVCAutoConfiguration {
+
+  @Bean
+  JsonbHttpMessageConverter jsonbConverter(Jsonb jsonb) {
+    return new JsonbHttpMessageConverter(jsonb);
+  }
+}

--- a/jsonb-spring-adapter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jsonb-spring-adapter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,2 @@
 io.avaje.jsonb.spring.JsonBAutoConfiguration
-io.avaje.jsonb.spring.JsonbMVCAutoConfiguration
+io.avaje.jsonb.spring.JsonbHttpConverterAutoConfiguration

--- a/jsonb-spring-adapter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/jsonb-spring-adapter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.avaje.jsonb.spring.JsonBAutoConfiguration
+io.avaje.jsonb.spring.JsonbMVCAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>jsonb</module>
     <module>jsonb-generator</module>
     <module>jsonb-jackson</module>
+    <module>jsonb-spring-adapter</module>
   </modules>
 
   <profiles>
@@ -48,4 +49,3 @@
   </profiles>
 
 </project>
-


### PR DESCRIPTION
Reflection heavy though it is, you cannot deny that spring is one of the most popular frameworks of all time. This PR adds a module that autoconfigures spring to serialize/deserialize JSON HTTP messages with avaje jsonb. 

tested with https://github.com/spring-guides/gs-spring-boot/tree/main/complete

Didn't do Webflux because I expect reactive APIs to eventually become even more uncommon with the advent of Loom