### PR TITLE
Fix Hard Inject Dependency (cyclical plugin dependency)

### DIFF
--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -11,7 +11,7 @@
   <name>jsonb generator</name>
   <description>annotation processor generating json adapters</description>
   <properties>
-    <avaje.prisms.version>1.6</avaje.prisms.version>
+    <avaje.prisms.version>1.8</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/jsonb-inject-plugin/pom.xml
+++ b/jsonb-inject-plugin/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>avaje-jsonb-parent</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>1.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>avaje-jsonb-inject-plugin</artifactId>
+  <name>jsonb-inject-plugin</name>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>1.4</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject</artifactId>
+      <version>9.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+ 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jsonb-inject-plugin/src/main/java/io/avaje/jsonb/inject/DefaultJsonbProvider.java
+++ b/jsonb-inject-plugin/src/main/java/io/avaje/jsonb/inject/DefaultJsonbProvider.java
@@ -1,4 +1,4 @@
-package io.avaje.jsonb.spi;
+package io.avaje.jsonb.inject;
 
 import io.avaje.inject.BeanScopeBuilder;
 import io.avaje.jsonb.Jsonb;

--- a/jsonb-inject-plugin/src/main/java/module-info.java
+++ b/jsonb-inject-plugin/src/main/java/module-info.java
@@ -1,8 +1,8 @@
 module io.avaje.jsonb.plugin {
 
-  requires static io.avaje.jsonb;
+  requires io.avaje.jsonb;
 
-  requires static io.avaje.inject;
+  requires io.avaje.inject;
 
   provides io.avaje.inject.spi.Plugin with io.avaje.jsonb.inject.DefaultJsonbProvider;
 }

--- a/jsonb-inject-plugin/src/main/java/module-info.java
+++ b/jsonb-inject-plugin/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.avaje.jsonb.plugin {
+
+  requires static io.avaje.jsonb;
+
+  requires static io.avaje.inject;
+
+  provides io.avaje.inject.spi.Plugin with io.avaje.jsonb.inject.DefaultJsonbProvider;
+}

--- a/jsonb-inject-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.Plugin
+++ b/jsonb-inject-plugin/src/main/resources/META-INF/services/io.avaje.inject.spi.Plugin
@@ -1,0 +1,1 @@
+io.avaje.jsonb.inject.DefaultJsonbProvider

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -12,12 +12,10 @@
 
   <dependencies>
 
-    <dependency>
+     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-inject</artifactId>
-      <version>9.0</version>
-      <scope>provided</scope>
-      <optional>true</optional>
+      <artifactId>avaje-jsonb-inject-plugin</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/jsonb/src/main/java/module-info.java
+++ b/jsonb/src/main/java/module-info.java
@@ -10,8 +10,6 @@ module io.avaje.jsonb {
   uses io.avaje.jsonb.JsonbComponent;
   uses io.avaje.jsonb.Jsonb.GeneratedComponent;
 
-  requires static io.avaje.inject;
   requires static io.helidon.nima.webserver;
 
-  provides io.avaje.inject.spi.Plugin with io.avaje.jsonb.spi.DefaultJsonbProvider;
 }

--- a/jsonb/src/main/resources/META-INF/services/io.avaje.inject.spi.Plugin
+++ b/jsonb/src/main/resources/META-INF/services/io.avaje.inject.spi.Plugin
@@ -1,1 +1,0 @@
-io.avaje.jsonb.spi.DefaultJsonbProvider

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>jsonb</module>
     <module>jsonb-generator</module>
     <module>jsonb-jackson</module>
+    <module>jsonb-inject-plugin</module>
     <module>jsonb-spring-adapter</module>
   </modules>
 


### PR DESCRIPTION
It seems we won't see multi-module jars for a couple of years. This was the recommended way the JDK devs said to do it.

Fixes #99 (this'll work on both the CP and module path)