### PR TITLE
Fix Subtype `toJson` for subtypes having same field name with different types.

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -560,9 +560,15 @@ final class ClassReader implements BeanReader {
           writer.eol().append("            _set$%s = true;", fieldName);
         }
       }
-      writer.eol().append("          }").eol().eol();
+      writer.eol().append("          }").eol();
     }
-      writer.eol().append("          break;").eol().eol();
+    writer
+        .append("          else {").eol()
+        .append("            throw new IllegalStateException(\"Missing Required type3 property that determines deserialization type\");")
+        .eol()
+        .append("          }")
+        .eol()
+        .append("          break;").eol().eol();
   }
 
 private String typePropertyKey() {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -358,15 +358,18 @@ final class FieldReader {
   }
 
   void writeFromJsonSwitch(
-      Append writer, boolean defaultConstructor, String varName, boolean caseInsensitiveKeys) {
+      Append writer,
+      boolean defaultConstructor,
+      String varName,
+      boolean caseInsensitiveKeys,
+      List<String> moreAlias) {
     if (unmapped) {
       return;
     }
-    if (aliases != null) {
-      for (final String alias : aliases) {
-        final String propertyKey = caseInsensitiveKeys ? alias.toLowerCase() : alias;
-        writer.append("        case \"%s\":", propertyKey).eol();
-      }
+    aliases.addAll(moreAlias);
+    for (final String alias : aliases) {
+      final String propertyKey = caseInsensitiveKeys ? alias.toLowerCase() : alias;
+      writer.append("        case \"%s\":", propertyKey).eol();
     }
     final String propertyKey = caseInsensitiveKeys ? propertyName.toLowerCase() : propertyName;
     writer.append("        case \"%s\": ", propertyKey).eol();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -31,8 +31,15 @@ final class FieldReader {
   private int genericTypeParamPosition;
   private final List<String> aliases;
   private boolean isSubTypeField;
+private final String num;
 
-  FieldReader(Element element, NamingConvention namingConvention, TypeSubTypeMeta subType, List<String> genericTypeParams) {
+  FieldReader(
+      Element element,
+      NamingConvention namingConvention,
+      TypeSubTypeMeta subType,
+      List<String> genericTypeParams,
+      Integer frequency) {
+     num = frequency == 0 ? "" : frequency.toString();
     addSubType(subType);
     this.genericTypeParams = genericTypeParams;
     this.fieldName = element.getSimpleName().toString();
@@ -310,17 +317,17 @@ final class FieldReader {
     if (unmapped) {
       return;
     }
-    String shortType = typeParamToObject(genericType.shortType());
-    writer.append("    %s _val$%s = %s;", pad(shortType), fieldName, defaultValue);
+    final String shortType = typeParamToObject(genericType.shortType());
+    writer.append("    %s _val$%s = %s;", pad(shortType), fieldName + num, defaultValue);
     if (!constructorParam) {
-      writer.append(" boolean _set$%s = false;", fieldName);
+      writer.append(" boolean _set$%s = false;", fieldName + num);
     }
     writer.eol();
   }
 
   void writeFromJsonVariablesRecord(Append writer) {
     final String type = genericTypeParameter ? "Object" : genericType.shortType();
-    writer.append("    %s _val$%s = %s;", pad(type), fieldName, defaultValue).eol();
+    writer.append("    %s _val$%s = %s;", pad(type), fieldName + num, defaultValue).eol();
   }
 
   private String pad(String value) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/MethodReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/MethodReader.java
@@ -51,14 +51,19 @@ final class MethodReader {
   static class MethodParam {
 
     private final String simpleName;
+    private final String type;
 
     MethodParam(VariableElement param) {
       this.simpleName = param.getSimpleName().toString();
+      this.type = param.asType().toString();
     }
 
     String name() {
       return simpleName;
     }
 
+    public String type() {
+      return type;
+    }
   }
 }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -37,6 +37,8 @@ final class TypeReader {
 
   private final String typePropertyKey;
 
+  private final Map<String, Integer> frequencyMap  = new HashMap<>();
+
   TypeReader(TypeElement baseType, TypeElement mixInType, NamingConvention namingConvention, String typePropertyKey) {
     this.baseType = baseType;
     this.genericTypeParams = initTypeParams(baseType);
@@ -85,15 +87,15 @@ final class TypeReader {
     }
     if (currentSubType == null && type != baseType) {
       allFields.addAll(0, localFields);
-      for (FieldReader localField : localFields) {
-        allFieldMap.put(localField.fieldName(), localField);
+      for (final FieldReader localField : localFields) {
+        allFieldMap.put(localField.fieldName()+localField.adapterShortType(), localField);
       }
     } else {
-      for (FieldReader localField : localFields) {
-        FieldReader commonField = allFieldMap.get(localField.fieldName());
+      for (final FieldReader localField : localFields) {
+        final FieldReader commonField = allFieldMap.get(localField.fieldName()+localField.adapterShortType());
         if (commonField == null) {
           allFields.add(localField);
-          allFieldMap.put(localField.fieldName(), localField);
+          allFieldMap.put(localField.fieldName()+localField.adapterShortType(), localField);
         } else {
           commonField.addSubType(currentSubType);
         }
@@ -111,7 +113,10 @@ final class TypeReader {
       element = mixInField;
     }
     if (includeField(element)) {
-      localFields.add(new FieldReader(element, namingConvention, currentSubType, genericTypeParams));
+      final var frequency =
+          frequencyMap.compute(element.getSimpleName().toString(), (k, v) -> v == null ? 0 : v + 1);
+      localFields.add(
+          new FieldReader(element, namingConvention, currentSubType, genericTypeParams,frequency));
     }
   }
 

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
@@ -1,0 +1,15 @@
+package io.avaje.jsonb.generator.models.valid;
+
+
+public class Example2Packet extends Packet {
+
+    private final String ids;
+
+    public Example2Packet (final String ids) {
+        this.ids = ids;
+    }
+
+    public String getIds() {
+        return this.ids;
+    }
+}

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
@@ -3,7 +3,7 @@ package io.avaje.jsonb.generator.models.valid;
 import io.avaje.jsonb.Json.JsonAlias;
 
 public class Example2Packet extends Packet {
-  @JsonAlias("packer")
+
   private final String ids;
   @JsonAlias("long-ring-long-land")
   private Long longy;

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example2Packet.java
@@ -1,15 +1,27 @@
 package io.avaje.jsonb.generator.models.valid;
 
+import io.avaje.jsonb.Json.JsonAlias;
 
 public class Example2Packet extends Packet {
+  @JsonAlias("packer")
+  private final String ids;
+  @JsonAlias("long-ring-long-land")
+  private Long longy;
 
-    private final String ids;
+  public Example2Packet(String ids, Long longy) {
+    this.ids = ids;
+    this.longy = longy;
+  }
 
-    public Example2Packet (final String ids) {
-        this.ids = ids;
-    }
+  public Long getLongy() {
+    return longy;
+  }
 
-    public String getIds() {
-        return this.ids;
-    }
+  public void setLongy(Long longy) {
+    this.longy = longy;
+  }
+
+  public String getIds() {
+    return ids;
+  }
 }

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example3Packet.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Example3Packet.java
@@ -1,0 +1,14 @@
+package io.avaje.jsonb.generator.models.valid;
+
+public class Example3Packet extends Packet {
+
+  private Character ids;
+
+  public void setIds(Character ids) {
+    this.ids = ids;
+  }
+
+  public Character getIds() {
+    return ids;
+  }
+}

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ExamplePacket.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ExamplePacket.java
@@ -4,14 +4,19 @@ import java.util.Set;
 
 public class ExamplePacket extends Packet {
 
-    private final Set<String> ids;
+  private final Set<String> ids;
+  private final Long longy;
 
-    public ExamplePacket (final Set<String> ids) {
-        this.ids = ids;
-    }
+  public ExamplePacket(Set<String> ids, Long longy) {
+    this.ids = ids;
+    this.longy = longy;
+  }
 
-    public Set<String> getIds() {
-        return this.ids;
-    }
+  public Long getLongy() {
+    return longy;
+  }
 
+  public Set<String> getIds() {
+    return this.ids;
+  }
 }

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ExamplePacket.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ExamplePacket.java
@@ -1,0 +1,17 @@
+package io.avaje.jsonb.generator.models.valid;
+
+import java.util.Set;
+
+public class ExamplePacket extends Packet {
+
+    private final Set<String> ids;
+
+    public ExamplePacket (final Set<String> ids) {
+        this.ids = ids;
+    }
+
+    public Set<String> getIds() {
+        return this.ids;
+    }
+
+}

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Packet.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Packet.java
@@ -1,0 +1,12 @@
+package io.avaje.jsonb.generator.models.valid;
+
+import io.avaje.jsonb.Json;
+
+@Json(naming = Json.Naming.LowerUnderscore, typeProperty = "type")
+@Json.SubTypes(
+    value = {
+      @Json.SubType(type = ExamplePacket.class, name = "example"),
+      @Json.SubType(type = Example2Packet.class, name = "example_2"),
+      @Json.SubType(type = Example3Packet.class)
+    })
+public abstract class Packet {}


### PR DESCRIPTION
This fixes the wrong adapters being used for `toJson` and `fromJson `

fixes https://github.com/avaje/avaje-jsonb/issues/102