### PR TITLE
IntelliJ - The .filter(Objects::nonNull) is always true

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -66,7 +66,6 @@ final class ClassReader implements BeanReader {
         .map(FieldReader::type)
         .map(GenericType::topType)
         .map(ProcessingContext::element)
-        .filter(Objects::nonNull)
         .filter(e -> e.getKind() == ElementKind.ENUM)
         .isPresent();
   }


### PR DESCRIPTION
IntelliJ is telling me that .filter(Objects::nonNull) is always true. The prior .map() is returning an Optional that is never null, so we should be able to remove this .filter() here.