### PR TITLE
Make JsonAdapter an Interface

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/ErrorResponse.java
+++ b/blackbox-test/src/main/java/org/example/customer/ErrorResponse.java
@@ -1,0 +1,6 @@
+package org.example.customer;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public record ErrorResponse(String id, String text) {}

--- a/blackbox-test/src/main/java/org/example/customer/customtype/CustomTypeComponent.java
+++ b/blackbox-test/src/main/java/org/example/customer/customtype/CustomTypeComponent.java
@@ -13,7 +13,7 @@ public class CustomTypeComponent implements JsonbComponent {
     builder.add(MyCustomScalarType.class, new CustomTypeAdapterWithStar().nullSafe());
   }
 
-  static class CustomTypeAdapterWithStar extends JsonAdapter<MyCustomScalarType> {
+  static class CustomTypeAdapterWithStar implements JsonAdapter<MyCustomScalarType> {
 
     @Override
     public void toJson(JsonWriter writer, MyCustomScalarType value) {

--- a/blackbox-test/src/test/java/org/example/customer/customtype/CustomScalarTypeTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/customtype/CustomScalarTypeTest.java
@@ -50,7 +50,7 @@ class CustomScalarTypeTest {
     assertThat(wrapper1.custom()).isEqualTo(wrapper.custom());
   }
 
-  static class CustomTypeAdapter extends JsonAdapter<MyCustomScalarType> {
+  static class CustomTypeAdapter implements JsonAdapter<MyCustomScalarType> {
 
     @Override
     public void toJson(JsonWriter writer, MyCustomScalarType value) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SimpleAdapterWriter.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SimpleAdapterWriter.java
@@ -1,9 +1,11 @@
 package io.avaje.jsonb.generator;
 
-import static io.avaje.jsonb.generator.ProcessingContext.*;
-import javax.tools.JavaFileObject;
+import static io.avaje.jsonb.generator.ProcessingContext.createWriter;
+
 import java.io.IOException;
 import java.io.Writer;
+
+import javax.tools.JavaFileObject;
 
 final class SimpleAdapterWriter {
 
@@ -17,7 +19,7 @@ final class SimpleAdapterWriter {
 
   SimpleAdapterWriter(BeanReader beanReader) {
     this.beanReader = beanReader;
-    AdapterName adapterName = new AdapterName(beanReader.getBeanType());
+    final AdapterName adapterName = new AdapterName(beanReader.getBeanType());
     this.adapterShortName = adapterName.shortName();
     this.adapterPackage = adapterName.adapterPackage();
     this.adapterFullName = adapterName.fullName();
@@ -29,7 +31,7 @@ final class SimpleAdapterWriter {
   }
 
   private Writer createFileWriter() throws IOException {
-    JavaFileObject jfo = createWriter(adapterFullName);
+    final JavaFileObject jfo = createWriter(adapterFullName);
     return jfo.openWriter();
   }
 
@@ -53,7 +55,7 @@ final class SimpleAdapterWriter {
   private void writeFactory() {
     if (genericParamsCount > 0) {
       String typeName = adapterShortName;
-      int nestedIndex = adapterShortName.indexOf("$");
+      final int nestedIndex = adapterShortName.indexOf("$");
       if (nestedIndex != -1) {
         typeName = typeName.substring(nestedIndex + 1);
       }
@@ -107,9 +109,9 @@ final class SimpleAdapterWriter {
 
   private void writeClassStart() {
     writer.append("@Generated").eol();
-    writer.append("public final class %sJsonAdapter extends JsonAdapter<%s> ", adapterShortName, beanReader.shortName());
+    writer.append("public final class %sJsonAdapter implements JsonAdapter<%s> ", adapterShortName, beanReader.shortName());
     if (!beanReader.hasSubtypes()) {
-      writer.append("implements ViewBuilderAware ");
+      writer.append(", ViewBuilderAware ");
     }
     writer.append("{").eol().eol();
   }

--- a/jsonb-jackson/src/test/java/org/example/AddressJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/AddressJsonAdapter.java
@@ -10,7 +10,7 @@ import io.avaje.jsonb.spi.ViewBuilderAware;
 
 import java.lang.invoke.MethodHandle;
 
-public class AddressJsonAdapter extends JsonAdapter<Address> implements ViewBuilderAware {
+public class AddressJsonAdapter implements JsonAdapter<Address>, ViewBuilderAware {
 
   private final JsonAdapter<String> stringAdapter;
   private final PropertyNames names;

--- a/jsonb-jackson/src/test/java/org/example/ContactJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/ContactJsonAdapter.java
@@ -9,7 +9,7 @@ import io.avaje.jsonb.spi.ViewBuilderAware;
 
 import java.lang.invoke.MethodHandle;
 
-public class ContactJsonAdapter extends JsonAdapter<Contact> implements ViewBuilderAware {
+public class ContactJsonAdapter implements JsonAdapter<Contact>, ViewBuilderAware {
 
   private final JsonAdapter<Long> longAdapter;
   private final JsonAdapter<String> stringAdapter;

--- a/jsonb-jackson/src/test/java/org/example/CustomerJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/CustomerJsonAdapter.java
@@ -9,7 +9,7 @@ import java.lang.invoke.MethodHandle;
 import java.time.Instant;
 import java.util.List;
 
-public class CustomerJsonAdapter extends JsonAdapter<Customer> implements ViewBuilderAware {
+public class CustomerJsonAdapter implements JsonAdapter<Customer>, ViewBuilderAware {
 
   private final JsonAdapter<Integer> intAdapter;
   private final JsonAdapter<String> stringAdapter;

--- a/jsonb-jackson/src/test/java/org/example/MyBasicJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/MyBasicJsonAdapter.java
@@ -12,7 +12,7 @@ import io.avaje.jsonb.spi.ViewBuilderAware;
 import java.lang.invoke.MethodHandle;
 
 @Generated
-public final class MyBasicJsonAdapter extends JsonAdapter<StreamBasicTest.MyBasic> implements ViewBuilderAware {
+public final class MyBasicJsonAdapter implements JsonAdapter<StreamBasicTest.MyBasic>, ViewBuilderAware {
 
   // naming convention Match
   // id [int] name:id constructor

--- a/jsonb-jackson/src/test/java/org/example/MyEnumJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/MyEnumJsonAdapter.java
@@ -12,7 +12,7 @@ import io.avaje.jsonb.Jsonb;
 import io.avaje.jsonb.spi.Generated;
 
 @Generated
-public final class MyEnumJsonAdapter extends JsonAdapter<MyEnum> {
+public final class MyEnumJsonAdapter implements JsonAdapter<MyEnum> {
 
   private static final Map<MyEnum, String> toValue = new EnumMap<>(MyEnum.class);
   private static final Map<String, MyEnum> toEnum = new HashMap<>();

--- a/jsonb-jackson/src/test/java/org/example/MyIntEnumJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/MyIntEnumJsonAdapter.java
@@ -10,7 +10,7 @@ import io.avaje.jsonb.JsonReader;
 import io.avaje.jsonb.JsonWriter;
 import io.avaje.jsonb.Jsonb;
 
-public final class MyIntEnumJsonAdapter extends JsonAdapter<MyIntEnum> {
+public final class MyIntEnumJsonAdapter implements JsonAdapter<MyIntEnum> {
 
   private static final Map<MyIntEnum, Integer> toValue = new EnumMap<>(MyIntEnum.class);
   private static final Map<Integer, MyIntEnum> toEnum = new HashMap<>();

--- a/jsonb/src/main/java/io/avaje/jsonb/JsonAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/JsonAdapter.java
@@ -15,29 +15,29 @@
  */
 package io.avaje.jsonb;
 
-import io.avaje.jsonb.spi.ViewBuilderAware;
-
 import java.lang.reflect.Type;
+
+import io.avaje.jsonb.spi.ViewBuilderAware;
 
 /**
  * The core API for serialization to and from json.
  */
-public abstract class JsonAdapter<T> {
+public interface JsonAdapter<T> {
 
   /**
    * Write the value to the writer.
    */
-  public abstract void toJson(JsonWriter writer, T value);
+  void toJson(JsonWriter writer, T value);
 
   /**
    * Read the type from the reader.
    */
-  public abstract T fromJson(JsonReader reader);
+  T fromJson(JsonReader reader);
 
   /**
    * Return a null safe version of this adapter.
    */
-  public final JsonAdapter<T> nullSafe() {
+  default JsonAdapter<T> nullSafe() {
     if (this instanceof NullSafeAdapter) {
       return this;
     }
@@ -47,14 +47,14 @@ public abstract class JsonAdapter<T> {
   /**
    * Return true if this adapter represents a json object or json array of objects that supports json views.
    */
-  public boolean isViewBuilderAware() {
+  default boolean isViewBuilderAware() {
     return false;
   }
 
   /**
    * Return the ViewBuilder.Aware for this adapter.
    */
-  public ViewBuilderAware viewBuild() {
+  default ViewBuilderAware viewBuild() {
     throw new IllegalStateException("This adapter is not ViewBuilderAware");
   }
 

--- a/jsonb/src/main/java/io/avaje/jsonb/NullSafeAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/NullSafeAdapter.java
@@ -17,7 +17,7 @@ package io.avaje.jsonb;
 
 import io.avaje.jsonb.spi.ViewBuilderAware;
 
-final class NullSafeAdapter<T> extends JsonAdapter<T> {
+final class NullSafeAdapter<T> implements JsonAdapter<T> {
 
   private final JsonAdapter<T> delegate;
 
@@ -43,7 +43,8 @@ final class NullSafeAdapter<T> extends JsonAdapter<T> {
     }
   }
 
-  public boolean isViewBuilderAware() {
+  @Override
+public boolean isViewBuilderAware() {
     return delegate.isViewBuilderAware();
   }
 

--- a/jsonb/src/main/java/io/avaje/jsonb/core/ArrayAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/ArrayAdapter.java
@@ -28,7 +28,7 @@ import java.util.List;
  * Converts arrays to JSON arrays containing their converted contents.
  * This supports both primitive and object arrays.
  */
-final class ArrayAdapter extends JsonAdapter<Object> {
+final class ArrayAdapter implements JsonAdapter<Object> {
   static final Factory FACTORY = (type, jsonb) -> {
     Type elementType = Util.arrayComponentType(type);
     if (elementType == null) return null;
@@ -75,7 +75,7 @@ final class ArrayAdapter extends JsonAdapter<Object> {
     return elementAdapter + ".array()";
   }
 
-  static final class ByteArray extends JsonAdapter<byte[]> {
+  static final class ByteArray implements JsonAdapter<byte[]> {
     @Override
     public byte[] fromJson(JsonReader reader) {
       return reader.readBinary();

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -61,7 +61,7 @@ final class BasicTypeAdapters {
         return null;
       };
 
-  private static final class UuidAdapter extends JsonAdapter<UUID> {
+  private static final class UuidAdapter implements JsonAdapter<UUID> {
     @Override
     public UUID fromJson(JsonReader reader) {
       return UUID.fromString(reader.readString());
@@ -78,7 +78,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  private static final class UrlAdapter extends JsonAdapter<URL> {
+  private static final class UrlAdapter implements JsonAdapter<URL> {
     @Override
     public URL fromJson(JsonReader reader) {
       try {
@@ -99,7 +99,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  private static final class UriAdapter extends JsonAdapter<URI> {
+  private static final class UriAdapter implements JsonAdapter<URI> {
     @Override
     public URI fromJson(JsonReader reader) {
       return URI.create(reader.readString());
@@ -116,7 +116,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class BooleanAdapter extends JsonAdapter<Boolean> {
+  static final class BooleanAdapter implements JsonAdapter<Boolean> {
     @Override
     public Boolean fromJson(JsonReader reader) {
       return reader.readBoolean();
@@ -133,7 +133,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class ByteAdapter extends JsonAdapter<Byte> {
+  static final class ByteAdapter implements JsonAdapter<Byte> {
     @Override
     public Byte fromJson(JsonReader reader) {
       return (byte) rangeCheckNextInt(reader, "a byte", -128, 255);
@@ -150,7 +150,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class CharacterAdapter extends JsonAdapter<Character> {
+  static final class CharacterAdapter implements JsonAdapter<Character> {
     @Override
     public Character fromJson(JsonReader reader) {
       String value = reader.readString();
@@ -172,7 +172,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class DoubleAdapter extends JsonAdapter<Double> {
+  static final class DoubleAdapter implements JsonAdapter<Double> {
     @Override
     public Double fromJson(JsonReader reader) {
       return reader.readDouble();
@@ -189,7 +189,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class FloatAdapter extends JsonAdapter<Float> {
+  static final class FloatAdapter implements JsonAdapter<Float> {
     @Override
     public Float fromJson(JsonReader reader) {
       float value = (float) reader.readDouble();
@@ -212,7 +212,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class IntegerAdapter extends JsonAdapter<Integer> {
+  static final class IntegerAdapter implements JsonAdapter<Integer> {
     @Override
     public Integer fromJson(JsonReader reader) {
       return reader.readInt();
@@ -229,7 +229,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class LongAdapter extends JsonAdapter<Long> {
+  static final class LongAdapter implements JsonAdapter<Long> {
     @Override
     public Long fromJson(JsonReader reader) {
       return reader.readLong();
@@ -246,7 +246,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class ShortAdapter extends JsonAdapter<Short> {
+  static final class ShortAdapter implements JsonAdapter<Short> {
     @Override
     public Short fromJson(JsonReader reader) {
       return (short) rangeCheckNextInt(reader, "a short", -32768, 32767);
@@ -263,7 +263,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static final class StringAdapter extends JsonAdapter<String> {
+  static final class StringAdapter implements JsonAdapter<String> {
     @Override
     public String fromJson(JsonReader reader) {
       return reader.readString();
@@ -290,7 +290,7 @@ final class BasicTypeAdapters {
   }
 
   @SuppressWarnings("rawtypes")
-  static final class ObjectJsonAdapter extends JsonAdapter<Object> {
+  static final class ObjectJsonAdapter implements JsonAdapter<Object> {
     private final Jsonb jsonb;
     private final JsonAdapter<List> listJsonAdapter;
     private final JsonAdapter<Map> mapAdapter;
@@ -352,7 +352,7 @@ final class BasicTypeAdapters {
     }
   }
 
-  static class EnumJsonAdapter<T extends Enum<T>> extends JsonAdapter<T> {
+  static class EnumJsonAdapter<T extends Enum<T>> implements JsonAdapter<T> {
 
     protected final Class<T> enumType;
 

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CollectionAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CollectionAdapter.java
@@ -26,7 +26,7 @@ import java.util.*;
 /**
  * Converts collection types to JSON arrays containing their converted contents.
  */
-abstract class CollectionAdapter<C extends Collection<T>, T> extends JsonAdapter<C> implements ViewBuilderAware {
+abstract class CollectionAdapter<C extends Collection<T>, T> implements JsonAdapter<C>, ViewBuilderAware {
 
   static final JsonAdapter.Factory FACTORY = (type, jsonb) -> {
     Class<?> rawType = Util.rawType(type);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
@@ -200,7 +200,7 @@ final class CoreAdapterBuilder {
   /**
    * This class implements {@code JsonAdapter} so it can be used as a stub for re-entrant calls.
    */
-  static final class Lookup<T> extends JsonAdapter<T> {
+  static final class Lookup<T> implements JsonAdapter<T> {
     final Type type;
     final Object cacheKey;
     JsonAdapter<T> adapter;

--- a/jsonb/src/main/java/io/avaje/jsonb/core/MapAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/MapAdapter.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * Converts maps with string keys to JSON objects.
  */
-final class MapAdapter<V> extends JsonAdapter<Map<String, V>> {
+final class MapAdapter<V> implements JsonAdapter<Map<String, V>> {
 
   static final Factory FACTORY = (type, jsonb) -> {
     Class<?> rawType = Util.rawType(type);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/MathAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/MathAdapters.java
@@ -26,7 +26,7 @@ final class MathAdapters implements JsonAdapter.Factory {
     return null;
   }
 
-  private static final class DecimalString extends JsonAdapter<BigDecimal> {
+  private static final class DecimalString implements JsonAdapter<BigDecimal> {
     @Override
     public BigDecimal fromJson(JsonReader reader) {
       return new BigDecimal(reader.readString());
@@ -43,7 +43,7 @@ final class MathAdapters implements JsonAdapter.Factory {
     }
   }
 
-  private static final class DecimalNumber extends JsonAdapter<BigDecimal> {
+  private static final class DecimalNumber implements JsonAdapter<BigDecimal> {
     @Override
     public BigDecimal fromJson(JsonReader reader) {
       return reader.readDecimal();
@@ -60,7 +60,7 @@ final class MathAdapters implements JsonAdapter.Factory {
     }
   }
 
-  private static final class BigIntString extends JsonAdapter<BigInteger> {
+  private static final class BigIntString implements JsonAdapter<BigInteger> {
     @Override
     public BigInteger fromJson(JsonReader reader) {
       return new BigInteger(reader.readString());
@@ -77,7 +77,7 @@ final class MathAdapters implements JsonAdapter.Factory {
     }
   }
 
-  private static final class BigIntNumber extends JsonAdapter<BigInteger> {
+  private static final class BigIntNumber implements JsonAdapter<BigInteger> {
     @Override
     public BigInteger fromJson(JsonReader reader) {
       return reader.readBigInteger();

--- a/jsonb/src/main/java/io/avaje/jsonb/core/RawAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/RawAdapter.java
@@ -8,7 +8,7 @@ final class RawAdapter {
 
   static final JsonAdapter<String> STR = new Str().nullSafe();
 
-  private static final class Str extends JsonAdapter<String> {
+  private static final class Str implements JsonAdapter<String> {
 
     @Override
     public void toJson(JsonWriter writer, String value) {

--- a/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
 
-final class StreamAdapter<T> extends JsonAdapter<Stream<T>> implements DJsonClosable<Stream<T>> {
+final class StreamAdapter<T> implements JsonAdapter<Stream<T>>, DJsonClosable<Stream<T>> {
 
   private final JsonAdapter<T> elementAdapter;
 


### PR DESCRIPTION
It occurs to me that JsonAdapter doesn't need to be an abstract class. Maybe we should put this in 2.0 since anybody creating their own custom adapters(but why??) would get a compilation error.