### PR TITLE
Refactor generator TypeSubTypeMeta to use SubTypeRequest

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -406,10 +406,11 @@ final class ClassReader implements BeanReader {
     }
     // another frequency map to append numbers to the subtype constructor params
     final Map<String, Integer> frequencyMap2 = new HashMap<>();
+    final var req = new SubTypeRequest(typeVar, this, useSwitch, useEnum, frequencyMap2, isCommonFieldMap);
 
     for (final TypeSubTypeMeta subTypeMeta : typeReader.subTypes()) {
       final var varName = Util.initLower(Util.shortName(subTypeMeta.type()));
-         subTypeMeta.writeFromJsonBuild(writer, typeVar, varName, this, useSwitch, useEnum, frequencyMap2, isCommonFieldMap);
+      subTypeMeta.writeFromJsonBuild(writer, varName, req);
     }
     if (useSwitch) {
       writer.append("      default").appendSwitchCase().eol().append("    ");

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SubTypeRequest.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/SubTypeRequest.java
@@ -1,0 +1,47 @@
+package io.avaje.jsonb.generator;
+
+import java.util.Map;
+
+final class SubTypeRequest {
+
+  private final String typeVar;
+  private final ClassReader beanReader;
+  private final boolean useSwitch;
+  private final boolean useEnum;
+  private final Map<String, Integer> frequencyMap;
+  private final Map<String, Boolean> commonFieldMap;
+
+  SubTypeRequest(String typeVar, ClassReader beanReader, boolean useSwitch, boolean useEnum, Map<String, Integer> frequencyMap, Map<String, Boolean> commonFieldMap) {
+    this.typeVar = typeVar;
+    this.beanReader = beanReader;
+    this.useSwitch = useSwitch;
+    this.useEnum = useEnum;
+    this.frequencyMap = frequencyMap;
+    this.commonFieldMap = commonFieldMap;
+  }
+
+  String typeVar() {
+    return typeVar;
+  }
+
+  ClassReader beanReader() {
+    return beanReader;
+  }
+
+  boolean useSwitch() {
+    return useSwitch;
+  }
+
+  boolean useEnum() {
+    return useEnum;
+  }
+
+  boolean isCommonField(String paramName) {
+    return Boolean.TRUE.equals(commonFieldMap.get(paramName));
+  }
+
+  String frequencySuffix(String constructParamName) {
+    var frequency = frequencyMap.compute(constructParamName, (k, v) -> v == null ? 0 : v + 1);
+    return frequency == 0 ? "" : frequency.toString();
+  }
+}


### PR DESCRIPTION
Refactoring to reduce method arguments passed around, by introducing SubTypeRequest. Also means we can hide the frequency and common name maps to be internal to SubTypeRequest