### PR TITLE
Now can use List/Set/Stream impls directly

### DIFF
--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -11,7 +11,7 @@
   <name>jsonb generator</name>
   <description>annotation processor generating json adapters</description>
   <properties>
-    <avaje.prisms.version>1.8</avaje.prisms.version>
+    <avaje.prisms.version>1.9</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -79,6 +79,10 @@ final class ProcessingContext {
     CTX.get().messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
   }
 
+  static void logNote(String msg, Object... args) {
+    CTX.get().messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
+  }
+
   static void logDebug(String msg, Object... args) {
     CTX.get().messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
   }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -49,7 +49,7 @@ final class ProcessingContext {
   private static boolean initPreviewEnabled(ProcessingEnvironment processingEnv) {
     try {
       return (boolean) ProcessingEnvironment.class.getDeclaredMethod("isPreviewEnabled").invoke(processingEnv);
-    } catch (Throwable e) {
+    } catch (final Throwable e) {
       return false;
     }
   }
@@ -90,6 +90,10 @@ final class ProcessingContext {
 
   static FileObject createMetaInfWriterFor(String interfaceType) throws IOException {
     return CTX.get().filer.createResource(StandardLocation.CLASS_OUTPUT, "", interfaceType);
+  }
+
+  static boolean isAssignable2Interface(String type, String superType) {
+    return element(type).getInterfaces().stream().anyMatch(t -> t.toString().contains(superType));
   }
 
   static TypeElement element(String rawType) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
@@ -10,6 +10,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -198,7 +199,18 @@ public final class Processor extends AbstractProcessor {
   }
 
   private void writeAdapter(TypeElement typeElement, BeanReader beanReader) {
+    if ((typeElement.getModifiers().contains(Modifier.ABSTRACT)
+            || typeElement.getKind() == ElementKind.INTERFACE)
+        && !SubTypePrism.isPresent(typeElement)
+        && !SubTypesPrism.isPresent(typeElement)) {
+      logNote(
+          "Type %s is abstract and has no configured subtypes. No Adapter will be generated for it.",
+          typeElement);
+      return;
+    }
+
     beanReader.read();
+    
     if (beanReader.nonAccessibleField()) {
       if (beanReader.hasJsonAnnotation()) {
         logError("Error JsonAdapter due to nonAccessibleField for %s ", beanReader);

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/ProcessorTest.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/ProcessorTest.java
@@ -1,7 +1,6 @@
 package io.avaje.jsonb.generator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +57,7 @@ class ProcessorTest {
 
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=8"), null, files);
+            new PrintWriter(System.out), null, null, Arrays.asList("--release=11"), null, files);
     task.setProcessors(Arrays.asList(new Processor()));
 
     assertThat(task.call()).isTrue();
@@ -73,7 +72,7 @@ class ProcessorTest {
 
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=8"), null, files);
+            new PrintWriter(System.out), null, null, Arrays.asList("--release=11"), null, files);
     task.setProcessors(Arrays.asList(new Processor()));
 
     assertThat(task.call()).isFalse();
@@ -81,24 +80,6 @@ class ProcessorTest {
         .sorted(Comparator.reverseOrder())
         .map(Path::toFile)
         .forEach(File::delete);
-  }
-
-  @Test
-  void testInvalidCollection() throws Exception {
-
-    final Iterable<JavaFileObject> files = getInvalidSourceFile("InvalidCollection");
-
-    final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-
-    final CompilationTask task =
-        compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=8"), null, files);
-    task.setProcessors(Arrays.asList(new Processor()));
-
-    assertThatExceptionOfType(RuntimeException.class)
-        .isThrownBy(task::call)
-        .havingCause()
-        .isInstanceOf(IllegalArgumentException.class);
   }
 
   private Iterable<JavaFileObject> getInvalidSourceFile(String name) throws Exception {

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ArrayListCollection.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ArrayListCollection.java
@@ -1,11 +1,11 @@
-package io.avaje.jsonb.generator.models.invalid;
+package io.avaje.jsonb.generator.models.valid;
 
 import java.util.ArrayList;
 
 import io.avaje.jsonb.Json;
 
 @Json
-public class InvalidCollection {
+public class ArrayListCollection {
   private ArrayList<String> list;
 
   public ArrayList<String> getList() {


### PR DESCRIPTION
Now we can do something like this. 
```
@Json
public class ArrayListCollection {
  private ArrayList<String> list;

  public ArrayList<String> getList() {
    return list;
  }
  public void setList(ArrayList<String> list) {
    this.list = list;
  }
}
```
(I personally would never do this, but some libs generate classes that use an impl directly).

- now will not fail compilation when JSON is placed on an abstract type.
- will check a types interfaces to see if it implements list/set/stream.