### PR TITLE
transitive plugin dependencies

### DIFF
--- a/jsonb-inject-plugin/src/main/java/module-info.java
+++ b/jsonb-inject-plugin/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.avaje.jsonb.plugin {
 
-  requires io.avaje.jsonb;
-  requires io.avaje.inject;
+  requires transitive io.avaje.jsonb;
+  requires transitive io.avaje.inject;
 
   provides io.avaje.inject.spi.Plugin with io.avaje.jsonb.inject.DefaultJsonbProvider;
 }


### PR DESCRIPTION
now can just add `requires io.avaje.jsonb.plugin` and have the jsonb module resolved.  