### PR TITLE
Restrict Optional Detection

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
@@ -16,7 +16,7 @@ final class PrimitiveUtil {
     wrapperMap.put("double", "Double");
     wrapperMap.put("float", "Float");
     wrapperMap.put("boolean", "Boolean");
-    //optionals
+    // optionals
     wrapperMap.put("OptionalInt", "");
     wrapperMap.put("OptionalDouble", "");
     wrapperMap.put("OptionalLong", "");
@@ -28,12 +28,11 @@ final class PrimitiveUtil {
   }
 
   static boolean isPrimitive(String typeShortName) {
-    return wrapperMap.containsKey(typeShortName)
-        || isOptional(typeShortName);
+    return wrapperMap.containsKey(typeShortName) || isOptional(typeShortName);
   }
 
   static String defaultValue(String shortType) {
-    if (isOptional(shortType)) {
+    if (shortType.contains("Optional")) {
       if (shortType.contains("<")) {
         return "Optional.empty()";
       }
@@ -44,7 +43,6 @@ final class PrimitiveUtil {
   }
 
   private static boolean isOptional(String typeShortName) {
-    return wrapperMap.containsKey(typeShortName)
-        || typeShortName.length() > 9 && "Optional<".equals(typeShortName.substring(0, 9));
+    return typeShortName.length() > 9 && "Optional<".equals(typeShortName.substring(0, 9));
   }
 }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 final class PrimitiveUtil {
 
-  static Map<String, String> wrapperMap = new HashMap<>();
+  private static Map<String, String> wrapperMap = new HashMap<>();
 
   static {
     wrapperMap.put("char", "Character");
@@ -17,9 +17,9 @@ final class PrimitiveUtil {
     wrapperMap.put("float", "Float");
     wrapperMap.put("boolean", "Boolean");
     //optionals
-    wrapperMap.put("OptionalInt", "OptionalInt");
-    wrapperMap.put("OptionalDouble", "OptionalDouble");
-    wrapperMap.put("OptionalLong", "OptionalLong");
+    wrapperMap.put("OptionalInt", "");
+    wrapperMap.put("OptionalDouble", "");
+    wrapperMap.put("OptionalLong", "");
   }
 
   static String wrap(String shortName) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PrimitiveUtil.java
@@ -16,6 +16,10 @@ final class PrimitiveUtil {
     wrapperMap.put("double", "Double");
     wrapperMap.put("float", "Float");
     wrapperMap.put("boolean", "Boolean");
+    //optionals
+    wrapperMap.put("OptionalInt", "OptionalInt");
+    wrapperMap.put("OptionalDouble", "OptionalDouble");
+    wrapperMap.put("OptionalLong", "OptionalLong");
   }
 
   static String wrap(String shortName) {
@@ -25,18 +29,22 @@ final class PrimitiveUtil {
 
   static boolean isPrimitive(String typeShortName) {
     return wrapperMap.containsKey(typeShortName)
-        || typeShortName.startsWith("Optional");
+        || isOptional(typeShortName);
   }
 
   static String defaultValue(String shortType) {
-    if (shortType.length() > 8 && "Optional".equals(shortType.substring(0, 8))) {
+    if (isOptional(shortType)) {
       if (shortType.contains("<")) {
         return "Optional.empty()";
       }
-
       return shortType + ".empty()";
     }
 
     return "boolean".equals(shortType) ? "false" : "0";
+  }
+
+  private static boolean isOptional(String typeShortName) {
+    return wrapperMap.containsKey(typeShortName)
+        || typeShortName.length() > 9 && "Optional<".equals(typeShortName.substring(0, 9));
   }
 }


### PR DESCRIPTION
So that types like `OptionalFoo` are not generated incorrectly