### PR TITLE
Make generator's jsonb optional

### DIFF
--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -11,7 +11,7 @@
   <name>jsonb generator</name>
   <description>annotation processor generating json adapters</description>
   <properties>
-    <avaje.prisms.version>1.9</avaje.prisms.version>
+    <avaje.prisms.version>1.10</avaje.prisms.version>
   </properties>
 
   <dependencies>
@@ -20,6 +20,8 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
       <version>${project.version}</version>
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Since avaje http no longer uses Class.forName to detect Jsonb, we can make this optional.