### PR TITLE
#138 Missing commas between array elements is allowed when parsing exception is expected

### DIFF
--- a/jsonb/src/main/java/io/avaje/jsonb/JsonReader.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/JsonReader.java
@@ -41,6 +41,15 @@ public interface JsonReader extends Closeable {
   }
 
   /**
+   * Return true if there is a next element in an ARRAY or x-json-stream (new line delimited json content).
+   * <p>
+   * Effectively this allows for new line delimited rather than commas between array elements.
+   */
+  default boolean hasNextStreamElement() {
+    return hasNextElement();
+  }
+
+  /**
    * Read array begin.
    */
   void beginArray();

--- a/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
@@ -54,7 +54,7 @@ final class StreamAdapter<T> implements JsonAdapter<Stream<T>>, DJsonClosable<St
 
     @Override
     public boolean hasNext() {
-      final boolean result = reader.hasNextElement();
+      final boolean result = reader.hasNextStreamElement();
       if (!result) {
         endStream();
       }

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JsonParser.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JsonParser.java
@@ -20,10 +20,15 @@ interface JsonParser extends Closeable {
   byte nextToken();
 
   /**
+   * Return true if there is a next element of an ARRAY.
+   */
+  boolean hasNextElement();
+
+  /**
    * Return true if there is a next element of an ARRAY or stream.
    * Support x-json-stream new line delimited json.
    */
-  boolean hasNextElement();
+  boolean hasNextStreamElement();
 
   /**
    * Read and return the field name.

--- a/jsonb/src/main/java/io/avaje/jsonb/stream/JsonReadAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/stream/JsonReadAdapter.java
@@ -56,6 +56,10 @@ final class JsonReadAdapter implements JsonReader {
     return reader.hasNextElement();
   }
 
+  public boolean hasNextStreamElement() {
+    return reader.hasNextStreamElement();
+  }
+
   @Override
   public boolean hasNextField() {
     byte nextToken = reader.nextToken();

--- a/jsonb/src/test/java/io/avaje/jsonb/stream/ArrayTest.java
+++ b/jsonb/src/test/java/io/avaje/jsonb/stream/ArrayTest.java
@@ -1,0 +1,146 @@
+package io.avaje.jsonb.stream;
+
+import io.avaje.jsonb.JsonDataException;
+import io.avaje.jsonb.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArrayTest {
+
+  final JsonStream adapter = JsonStream.builder().serializeNulls(true).serializeEmpty(true).failOnUnknown(false).build();
+
+  @Test
+  void readArrayEmpty() {
+    try (JsonReader reader = adapter.reader("[]")) {
+      reader.beginArray();
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+  @Test
+  void readArrayEmptyWithWhitespace() {
+    try (JsonReader reader = adapter.reader("[ \n \n  ]")) {
+      reader.beginArray();
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+  @Test
+  void readArraySingleNumber() {
+    try (JsonReader reader = adapter.reader("[42]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readInt()).isEqualTo(42);
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+  @Test
+  void readArrayMultipleNumber() {
+    try (JsonReader reader = adapter.reader("[ 42, 43]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readInt()).isEqualTo(42);
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readInt()).isEqualTo(43);
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+
+
+  @Test
+  void readArrayMultipleString() {
+    try (JsonReader reader = adapter.reader("[\"zz\",\"xx\",\"yy\"]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      assertEquals("zz", reader.readString());
+      assertTrue(reader.hasNextElement());
+      assertEquals("xx", reader.readString());
+      assertTrue(reader.hasNextElement());
+      assertEquals("yy", reader.readString());
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+  @Test
+  void readMultipleObject() {
+    try (JsonReader reader = adapter.reader("[ {\"key\":\"a\"}, {\"key\":\"b\"} ]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      reader.beginObject();
+      assertThat(reader.hasNextField()).isTrue();
+      assertThat(reader.nextField()).isEqualTo("key");
+      assertThat(reader.readString()).isEqualTo("a");
+      reader.endObject();
+
+      assertTrue(reader.hasNextElement());
+      reader.beginObject();
+      assertThat(reader.hasNextField()).isTrue();
+      assertThat(reader.nextField()).isEqualTo("key");
+      assertThat(reader.readString()).isEqualTo("b");
+      reader.endObject();
+
+      assertFalse(reader.hasNextElement());
+      reader.endArray();
+    }
+  }
+
+  @Test
+  void missingCommasAsString() {
+    try (JsonReader reader = adapter.reader("[ \"a\" \"b\"]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readString()).isEqualTo("a");
+      String message = assertThrows(JsonDataException.class, reader::hasNextElement).getMessage();
+      assertThat(message).contains("Expecting ']' or ',' for end of array element, instead found '\"'");
+    }
+  }
+
+  @Test
+  void missingCommasAsObject() {
+    try (JsonReader reader = adapter.reader("[ {\"key\":\"a\"} {\"key\":\"b\"} ]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      reader.beginObject();
+      assertThat(reader.hasNextField()).isTrue();
+      assertThat(reader.nextField()).isEqualTo("key");
+      assertThat(reader.readString()).isEqualTo("a");
+      reader.endObject();
+
+      String message = assertThrows(JsonDataException.class, reader::hasNextElement).getMessage();
+      assertThat(message).contains("Expecting ']' or ',' for end of array element, instead found '{'");
+    }
+  }
+
+  @Test
+  void missingCommasAsNumber_expect_errorParsingNumber() {
+    try (JsonReader reader = adapter.reader("[ 42 43]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      String message = assertThrows(JsonDataException.class, reader::readInt).getMessage();
+      assertThat(message).contains("Error parsing number");
+    }
+  }
+
+  @Test
+  void extraCommasAsNumber_expect_errorParsingNumber() {
+    try (JsonReader reader = adapter.reader("[ 42, 43, ]")) {
+      reader.beginArray();
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readInt()).isEqualTo(42);
+      assertTrue(reader.hasNextElement());
+      assertThat(reader.readInt()).isEqualTo(43);
+      assertTrue(reader.hasNextElement());
+      String message = assertThrows(JsonDataException.class, reader::readInt).getMessage();
+      assertThat(message).contains("Error parsing number");
+    }
+  }
+}

--- a/jsonb/src/test/java/io/avaje/jsonb/stream/StreamTest.java
+++ b/jsonb/src/test/java/io/avaje/jsonb/stream/StreamTest.java
@@ -1,0 +1,48 @@
+package io.avaje.jsonb.stream;
+
+import io.avaje.jsonb.JsonReader;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StreamTest {
+
+  final JsonStream adapter = JsonStream.builder().serializeNulls(true).serializeEmpty(true).failOnUnknown(false).build();
+
+  @Test
+  void readStreamMultipleObjectArrays() {
+    readStream("[ {\"key\":\"a\"} , {\"key\":\"b\"} ]");
+    readStream("[ {\"key\":\"a\"} \n {\"key\":\"b\"} ]");
+  }
+
+  @Test
+  void readStreamMultipleObject() {
+    readStream("{\"key\":\"a\"},{\"key\":\"b\"}");
+    readStream("{\"key\":\"a\"}\n{\"key\":\"b\"}");
+    readStream("{\"key\":\"a\"} \n {\"key\":\"b\"}");
+  }
+
+  private void readStream(String rawJson) {
+    try (JsonReader reader = adapter.reader(rawJson)) {
+      reader.beginStream();
+      assertTrue(reader.hasNextStreamElement());
+      reader.beginObject();
+      assertThat(reader.hasNextField()).isTrue();
+      assertThat(reader.nextField()).isEqualTo("key");
+      assertThat(reader.readString()).isEqualTo("a");
+      reader.endObject();
+
+      assertTrue(reader.hasNextStreamElement());
+      reader.beginObject();
+      assertThat(reader.hasNextField()).isTrue();
+      assertThat(reader.nextField()).isEqualTo("key");
+      assertThat(reader.readString()).isEqualTo("b");
+      reader.endObject();
+
+      assertFalse(reader.hasNextStreamElement());
+      reader.endStream();
+    }
+  }
+}


### PR DESCRIPTION
Adds hasNextStreamElement() which will be used for x-json-stream and thus the hasNextElement() is tightened up to expect the comma or ] and throws a parsing exception when that isn't the case.