### PR TITLE
Fix partial compile with component Factory (used for generic types)

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 final class ComponentReader {
-	
+
   private final ComponentMetaData componentMetaData;
 
   ComponentReader(ComponentMetaData metaData) {
@@ -44,16 +44,14 @@ final class ComponentReader {
       final FactoryPrism metaDataFactory = FactoryPrism.getInstance(annotationMirror);
 
       if (metaData != null) {
-
         metaData.value().stream()
             .map(TypeMirror::toString)
             .forEach(componentMetaData::add);
 
       } else if (metaDataFactory != null) {
-
         metaDataFactory.value().stream()
             .map(TypeMirror::toString)
-            .forEach(componentMetaData::add);
+            .forEach(componentMetaData::addFactory);
       }
     }
   }


### PR DESCRIPTION
Fix in ComponentReader to use addFactory() when reading back @MetaData.Factory types