### PR TITLE
Add support for Interface type fromJson() by specifying an implementation

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/iface/DIFace.java
+++ b/blackbox-test/src/main/java/org/example/customer/iface/DIFace.java
@@ -1,0 +1,8 @@
+package org.example.customer.iface;
+
+public interface DIFace {
+
+  String one();
+
+  long two();
+}

--- a/blackbox-test/src/main/java/org/example/customer/iface/EIFace.java
+++ b/blackbox-test/src/main/java/org/example/customer/iface/EIFace.java
@@ -1,0 +1,8 @@
+package org.example.customer.iface;
+
+public interface EIFace {
+
+  String one();
+
+  long two();
+}

--- a/blackbox-test/src/main/java/org/example/customer/iface/implementation/MyDIFace.java
+++ b/blackbox-test/src/main/java/org/example/customer/iface/implementation/MyDIFace.java
@@ -1,0 +1,15 @@
+package org.example.customer.iface.implementation;
+
+import io.avaje.jsonb.Json;
+import org.example.customer.iface.DIFace;
+import org.example.customer.iface.EIFace;
+
+@Json.Import(value = DIFace.class, implementation = MyDIFace.class)
+@Json.Import(value = EIFace.class)
+@Json
+public record MyDIFace(String one, long two) implements DIFace {
+
+  String banana() {
+    return one;
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/iface/BIFaceTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/iface/BIFaceTest.java
@@ -6,6 +6,7 @@ import io.avaje.jsonb.Jsonb;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BIFaceTest {
 
@@ -49,6 +50,14 @@ class BIFaceTest {
 
     JsonView<BIFace> view2 = type.view("(two)");
     assertThat(view2.toJson(new Foo("a", true, "b", "c"))).isEqualTo("{\"two\":true}");
+  }
+
+  @Test
+  void fromJson_expect_UnsupportedOperationException() {
+    JsonType<BIFace> type = jsonb.type(BIFace.class);
+    assertThatThrownBy(() -> {
+      type.fromJson("{\"one\":\"a\",\"two\":42}");
+    }).isInstanceOf(UnsupportedOperationException.class);
   }
 
 }

--- a/blackbox-test/src/test/java/org/example/customer/iface/CIFaceTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/iface/CIFaceTest.java
@@ -6,6 +6,7 @@ import io.avaje.jsonb.Jsonb;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CIFaceTest {
 
@@ -35,6 +36,14 @@ class CIFaceTest {
 
     JsonView<CIFace> view2 = type.view("(two-not-here)");
     assertThat(view2.toJson(new Foo("a", 42, "b"))).isEqualTo("{\"two-not-here\":42}");
+  }
+
+  @Test
+  void fromJson_expect_UnsupportedOperationException() {
+    JsonType<CIFace> type = jsonb.type(CIFace.class);
+    assertThatThrownBy(() -> {
+      type.fromJson("{\"one\":\"a\",\"two\":42}");
+    }).isInstanceOf(UnsupportedOperationException.class);
   }
 
 }

--- a/blackbox-test/src/test/java/org/example/customer/iface/DIFaceTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/iface/DIFaceTest.java
@@ -3,21 +3,22 @@ package org.example.customer.iface;
 import io.avaje.jsonb.JsonType;
 import io.avaje.jsonb.JsonView;
 import io.avaje.jsonb.Jsonb;
+import org.example.customer.iface.implementation.MyDIFace;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class AIFaceTest {
+class DIFaceTest {
 
   Jsonb jsonb = Jsonb.builder().build();
 
-  record Foo(String one, long two) implements AIFace {
+  record Foo(String one, long two) implements DIFace {
   }
 
   @Test
   void toJson() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
+    JsonType<DIFace> type = jsonb.type(DIFace.class);
 
     String asJson = type.toJson(new Foo("a", 42));
     assertThat(asJson).isEqualTo("{\"one\":\"a\",\"two\":42}");
@@ -25,24 +26,26 @@ class AIFaceTest {
 
   @Test
   void toJsonView() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
+    JsonType<DIFace> type = jsonb.type(DIFace.class);
 
-    JsonView<AIFace> view0 = type.view("(one)");
+    JsonView<DIFace> view0 = type.view("(one)");
     String asJson = view0.toJson(new Foo("a", 42));
     assertThat(asJson).isEqualTo("{\"one\":\"a\"}");
 
-    JsonView<AIFace> view1 = type.view("(one,two)");
+    JsonView<DIFace> view1 = type.view("(one,two)");
     assertThat(view1.toJson(new Foo("a", 42))).isEqualTo("{\"one\":\"a\",\"two\":42}");
 
-    JsonView<AIFace> view2 = type.view("(two)");
+    JsonView<DIFace> view2 = type.view("(two)");
     assertThat(view2.toJson(new Foo("a", 42))).isEqualTo("{\"two\":42}");
   }
 
   @Test
-  void fromJson_expect_UnsupportedOperationException() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
-    assertThatThrownBy(() -> {
-      type.fromJson("{\"one\":\"a\",\"two\":42}");
-    }).isInstanceOf(UnsupportedOperationException.class);
+  void fromJson() {
+    JsonType<DIFace> type = jsonb.type(DIFace.class);
+    DIFace bean = type.fromJson("{\"one\":\"a\",\"two\":42}");
+
+    assertThat(bean.one()).isEqualTo("a");
+    assertThat(bean.two()).isEqualTo(42L);
+    assertThat(bean).isInstanceOf(MyDIFace.class);
   }
 }

--- a/blackbox-test/src/test/java/org/example/customer/iface/EIFaceTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/iface/EIFaceTest.java
@@ -5,19 +5,21 @@ import io.avaje.jsonb.JsonView;
 import io.avaje.jsonb.Jsonb;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class AIFaceTest {
+class EIFaceTest {
 
   Jsonb jsonb = Jsonb.builder().build();
 
-  record Foo(String one, long two) implements AIFace {
+  record Foo(String one, long two) implements EIFace {
   }
 
   @Test
   void toJson() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
+    JsonType<EIFace> type = jsonb.type(EIFace.class);
 
     String asJson = type.toJson(new Foo("a", 42));
     assertThat(asJson).isEqualTo("{\"one\":\"a\",\"two\":42}");
@@ -25,22 +27,22 @@ class AIFaceTest {
 
   @Test
   void toJsonView() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
+    JsonType<EIFace> type = jsonb.type(EIFace.class);
 
-    JsonView<AIFace> view0 = type.view("(one)");
+    JsonView<EIFace> view0 = type.view("(one)");
     String asJson = view0.toJson(new Foo("a", 42));
     assertThat(asJson).isEqualTo("{\"one\":\"a\"}");
 
-    JsonView<AIFace> view1 = type.view("(one,two)");
+    JsonView<EIFace> view1 = type.view("(one,two)");
     assertThat(view1.toJson(new Foo("a", 42))).isEqualTo("{\"one\":\"a\",\"two\":42}");
 
-    JsonView<AIFace> view2 = type.view("(two)");
+    JsonView<EIFace> view2 = type.view("(two)");
     assertThat(view2.toJson(new Foo("a", 42))).isEqualTo("{\"two\":42}");
   }
 
   @Test
   void fromJson_expect_UnsupportedOperationException() {
-    JsonType<AIFace> type = jsonb.type(AIFace.class);
+    JsonType<EIFace> type = jsonb.type(EIFace.class);
     assertThatThrownBy(() -> {
       type.fromJson("{\"one\":\"a\",\"two\":42}");
     }).isInstanceOf(UnsupportedOperationException.class);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Constants.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Constants.java
@@ -8,6 +8,7 @@ final class Constants {
   static final String JSONB = "io.avaje.jsonb.Jsonb";
   static final String JSON = "io.avaje.jsonb.Json";
   static final String JSON_IMPORT = "io.avaje.jsonb.Json.Import";
+  static final String JSON_IMPORT_LIST = "io.avaje.jsonb.Json.Import.List";
   static final String JSON_MIXIN = "io.avaje.jsonb.Json.MixIn";
   static final String IOEXCEPTION = "java.io.IOException";
   static final String METHODHANDLE = "java.lang.invoke.MethodHandle";

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -115,6 +115,10 @@ final class ProcessingContext {
     return CTX.get().types.asElement(returnType);
   }
 
+  static TypeElement asTypeElement(TypeMirror returnType) {
+    return (TypeElement) asElement(returnType);
+  }
+
   static ProcessingEnvironment env() {
     return CTX.get().env;
   }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
@@ -1,6 +1,7 @@
 @GeneratePrism(io.avaje.jsonb.CustomAdapter.class)
 @GeneratePrism(io.avaje.jsonb.Json.class)
 @GeneratePrism(io.avaje.jsonb.Json.Import.class)
+@GeneratePrism(value = io.avaje.jsonb.Json.Import.List.class, name = "ImportListPrism")
 @GeneratePrism(io.avaje.jsonb.Json.JsonAlias.class)
 @GeneratePrism(io.avaje.jsonb.Json.Ignore.class)
 @GeneratePrism(io.avaje.jsonb.Json.Property.class)

--- a/jsonb/src/main/java/io/avaje/jsonb/Json.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Json.java
@@ -81,9 +81,14 @@ public @interface Json {
     /** Specify the Subtype information. Can only be used if there is only one abstract type being imported */
     SubType[] subtypes() default {};
 
+    /**
+     * When importing an Interface or abstract type use this implementation for `fromJson()`.
+     */
+    Class<?> implementation() default Void.class;
+
     @Retention(CLASS)
     @Target({ElementType.TYPE, ElementType.PACKAGE})
-    public @interface List {
+    @interface List {
 
       Import[] value();
     }


### PR DESCRIPTION
- Fixes a bug where Json.Import.List was not being read
- Adds support for Interface type fromJson() by specifying an implementation

e.g. `implementation = MyDIFace.class` - to support `fromJson()` for interface type

```java
 @Json.Import(value = DIFace.class, implementation = MyDIFace.class)
 public record MyDIFace(String one, long two) implements DIFace {
 ...
```

e.g. `@Json` (for the concrete type) + `@Json.Import` (for the interface + implementation)

```java
 @Json.Import(value = DIFace.class, implementation = MyDIFace.class)
 @Json
 public record MyDIFace(String one, long two) implements DIFace {
 ...
```