### PR TITLE
jsonb-generator module-info, should use static for io.avaje.jsonb.

### DIFF
--- a/jsonb-generator/src/main/java/module-info.java
+++ b/jsonb-generator/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.avaje.jsonb.generator {
 
   requires java.compiler;
-  requires io.avaje.jsonb;
+  requires static io.avaje.jsonb;
   requires static io.avaje.prism;
 
   provides javax.annotation.processing.Processor with io.avaje.jsonb.generator.Processor;

--- a/jsonb-inject-plugin/pom.xml
+++ b/jsonb-inject-plugin/pom.xml
@@ -17,19 +17,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb</artifactId>
-      <version>1.4</version>
+      <version>1.6</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
-    
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.0</version>
+      <version>9.4</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
- 
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
IntelliJ rebuild compile can fail when this is `requires`