### PR TITLE
Handle case of default constructor that we don't use 

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/ctor/MyMessage.java
+++ b/blackbox-test/src/main/java/org/example/customer/ctor/MyMessage.java
@@ -1,0 +1,34 @@
+package org.example.customer.ctor;
+
+
+import io.avaje.jsonb.Json;
+
+@Json
+public class MyMessage {
+
+  protected String path;
+  protected String field;
+  protected String message;
+
+  public MyMessage(String path, String field, String message) {
+    this.path = path;
+    this.field = field;
+    this.message = message;
+  }
+
+  /** Default constructor typically to help Jackson onlu. */
+  public MyMessage() {
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -11,7 +11,7 @@
   <name>jsonb generator</name>
   <description>annotation processor generating json adapters</description>
   <properties>
-    <avaje.prisms.version>1.14</avaje.prisms.version>
+    <avaje.prisms.version>1.16</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
@@ -259,8 +259,7 @@ public final class Processor extends AbstractProcessor {
   }
 
   private void writeAdapterForType(TypeElement typeElement) {
-    final ClassReader beanReader = new ClassReader(typeElement);
-    writeAdapter(typeElement, beanReader);
+    writeAdapter(typeElement, new ClassReader(typeElement));
   }
 
   private void writeAdapterForImportedType(TypeElement importedType, TypeElement implementationType) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -342,7 +342,7 @@ final class TypeReader {
   }
 
   private MethodReader determineConstructor() {
-    if (defaultPublicConstructor) {
+    if (defaultPublicConstructor && !allSetterMethods.isEmpty()) {
       return null;
     }
     if (publicConstructors.size() == 1) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -1,12 +1,12 @@
 package io.avaje.jsonb.generator;
 
-import static io.avaje.jsonb.generator.APContext.*;
-import static io.avaje.jsonb.generator.ProcessingContext.*;
-
 import javax.lang.model.element.*;
 import javax.lang.model.type.TypeMirror;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static io.avaje.jsonb.generator.APContext.*;
+import static io.avaje.jsonb.generator.ProcessingContext.importedJson;
 
 /**
  * Read points for field injection and method injection
@@ -41,12 +41,14 @@ final class TypeReader {
 
   private final String typePropertyKey;
 
-  private final Map<String, Integer> frequencyMap  = new HashMap<>();
+  private final Map<String, Integer> frequencyMap = new HashMap<>();
 
   private final List<MethodProperty> methodProperties = new ArrayList<>();
 
   private boolean optional;
-  /** Set when the type is known to extend Throwable */
+  /**
+   * Set when the type is known to extend Throwable
+   */
   private boolean extendsThrowable;
 
   TypeReader(TypeElement baseType, TypeElement mixInType, NamingConvention namingConvention, String typePropertyKey) {
@@ -98,14 +100,14 @@ final class TypeReader {
     if (currentSubType == null && type != baseType) {
       allFields.addAll(0, localFields);
       for (final FieldReader localField : localFields) {
-        allFieldMap.put(localField.fieldName()+localField.adapterShortType(), localField);
+        allFieldMap.put(localField.fieldName() + localField.adapterShortType(), localField);
       }
     } else {
       for (final FieldReader localField : localFields) {
-        final FieldReader commonField = allFieldMap.get(localField.fieldName()+localField.adapterShortType());
+        final FieldReader commonField = allFieldMap.get(localField.fieldName() + localField.adapterShortType());
         if (commonField == null) {
           allFields.add(localField);
-          allFieldMap.put(localField.fieldName()+localField.adapterShortType(), localField);
+          allFieldMap.put(localField.fieldName() + localField.adapterShortType(), localField);
         } else {
           commonField.addSubType(currentSubType);
         }
@@ -188,7 +190,7 @@ final class TypeReader {
       return false;
     }
     if (extendsThrowable) {
-     return THROWABLE_INCLUDES.contains(methodElement.getSimpleName().toString());
+      return THROWABLE_INCLUDES.contains(methodElement.getSimpleName().toString());
     }
     return true;
   }
@@ -465,7 +467,7 @@ final class TypeReader {
       var property = new FieldProperty(methodReader);
       property.setGetterMethod(methodReader);
       property.setPosition(pos);
-  pos++;
+      pos++;
       String name = initPropertyName(methodReader.getName(), property);
       String propertyName = namingConvention.from(name);
       methodProperties.add(new MethodProperty(propertyName, property));


### PR DESCRIPTION
This case comes about with the way Jackson wants
to have a default constructor, so it looks a little
odd but good to support.

e.g.

```java
@Json
public class MyMessage {

  protected String path;
  protected String field;
  protected String message;

  public MyMessage(String path, String field, String message) {
    this.path = path;
    this.field = field;
    this.message = message;
  }

  /** Default constructor typically to help Jackson onlu. */
  public MyMessage() {
  }

  public String getPath() {
    return path;
  }

  public String getField() {
    return field;
  }

  public String getMessage() {
    return message;
  }
}

```