### PR TITLE
Fix typo in ProcessingContext

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -108,7 +108,7 @@ final class ProcessingContext {
         if (noInjectPlugin.get()) {
           logWarn(
               module,
-              "`requires io.avaje.json.plugin` must be explicity added or else avaje-inject may fail to detect and wire the default Jsonb instance",
+              "`requires io.avaje.jsonb.plugin` must be explicity added or else avaje-inject may fail to detect and wire the default Jsonb instance",
               fqn);
         }
 


### PR DESCRIPTION
Should read `io.avaje.jsonb.plugin` instead of `.json.plugin`.