### PR TITLE
Fix Throwable Generation

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <java.release>17</java.release>
+    <java.release>21</java.release>
   </properties>
 
   <dependencies>

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -64,7 +64,8 @@ final class ClassReader implements BeanReader {
     this.optional = typeReader.hasOptional();
     this.isRecord = isRecord(beanType);
     this.subTypes = typeReader.subTypes();
-    this.readOnlyInterface = allFields.isEmpty() && subTypes.isEmpty();
+    this.readOnlyInterface =
+        typeReader.extendsThrowable() || allFields.isEmpty() && subTypes.isEmpty();
     this.methodProperties = typeReader.methodProperties();
 
     subTypes.stream().map(TypeSubTypeMeta::type).forEach(importTypes::add);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -19,7 +19,12 @@ final class FieldReader {
   private boolean isSubTypeField;
   private final String num;
 
-  FieldReader(Element element, NamingConvention namingConvention, TypeSubTypeMeta subType, List<String> genericTypeParams, Integer frequency) {
+  FieldReader(
+      Element element,
+      NamingConvention namingConvention,
+      TypeSubTypeMeta subType,
+      List<String> genericTypeParams,
+      Integer frequency) {
     num = frequency == 0 ? "" : frequency.toString();
     addSubType(subType);
     final PropertyIgnoreReader ignoreReader = new PropertyIgnoreReader(element);
@@ -30,12 +35,14 @@ final class FieldReader {
 
     final var fieldName = element.getSimpleName().toString();
     final var publicField = element.getModifiers().contains(Modifier.PUBLIC);
-    this.property = new FieldProperty(element.asType(), raw, unmapped, genericTypeParams, publicField, fieldName);
+    this.property =
+        new FieldProperty(
+            element.asType(), raw, unmapped, genericTypeParams, publicField, fieldName);
     this.propertyName =
-      PropertyPrism.getOptionalOn(element)
-        .map(PropertyPrism::value)
-        .map(Util::escapeQuotes)
-        .orElse(namingConvention.from(fieldName));
+        PropertyPrism.getOptionalOn(element)
+            .map(PropertyPrism::value)
+            .map(Util::escapeQuotes)
+            .orElse(namingConvention.from(fieldName));
 
     this.aliases = initAliases(element);
   }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Processor.java
@@ -65,7 +65,7 @@ public final class Processor extends AbstractProcessor {
   @Override
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment round) {
 
-	  APContext.setProjectModuleElement(annotations, round);
+    APContext.setProjectModuleElement(annotations, round);
     readModule();
     writeAdapters(round.getElementsAnnotatedWith(typeElement(JSON)));
     writeEnumAdapters(round.getElementsAnnotatedWith(typeElement(ValuePrism.PRISM_TYPE)));

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/ProcessorTest.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/ProcessorTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 
 import javax.tools.JavaCompiler;
@@ -48,17 +49,22 @@ class ProcessorTest {
     final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     final StandardJavaFileManager manager = compiler.getStandardFileManager(null, null, null);
 
-    manager.setLocation(StandardLocation.SOURCE_PATH, Arrays.asList(new File(source)));
+    manager.setLocation(StandardLocation.SOURCE_PATH, List.of(new File(source)));
 
-    final Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
+    final Set<Kind> fileKinds = Set.of(Kind.SOURCE);
 
     final Iterable<JavaFileObject> files =
         manager.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
 
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=11"), null, files);
-    task.setProcessors(Arrays.asList(new Processor()));
+            new PrintWriter(System.out),
+            null,
+            null,
+            List.of("--release=" + Integer.getInteger("java.specification.version")),
+            null,
+            files);
+    task.setProcessors(List.of(new Processor()));
 
     assertThat(task.call()).isTrue();
   }
@@ -72,8 +78,13 @@ class ProcessorTest {
 
     final CompilationTask task =
         compiler.getTask(
-            new PrintWriter(System.out), null, null, Arrays.asList("--release=11"), null, files);
-    task.setProcessors(Arrays.asList(new Processor()));
+            new PrintWriter(System.out),
+            null,
+            null,
+            List.of("--release=" + Integer.getInteger("java.specification.version")),
+            null,
+            files);
+    task.setProcessors(List.of(new Processor()));
 
     assertThat(task.call()).isFalse();
     Files.walk(Paths.get("java").toAbsolutePath())
@@ -88,18 +99,18 @@ class ProcessorTest {
 
     files.setLocation(
         StandardLocation.SOURCE_PATH,
-        Arrays.asList(
+        List.of(
             new File(
                 Paths.get("src/test/java/io/avaje/jsonb/generator/models/invalid")
                     .toAbsolutePath()
                     .toString())));
 
-    final Set<Kind> fileKinds = Collections.singleton(Kind.SOURCE);
+    final Set<Kind> fileKinds = Set.of(Kind.SOURCE);
     final Iterable<JavaFileObject> jfos =
         files.list(StandardLocation.SOURCE_PATH, "", fileKinds, true);
 
     for (final JavaFileObject jfo : jfos) {
-      if (jfo.getName().contains(name)) return Collections.singleton(jfo);
+      if (jfo.getName().contains(name)) return Set.of(jfo);
     }
 
     return null;

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/MyThrowable.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/MyThrowable.java
@@ -1,0 +1,14 @@
+package io.avaje.jsonb.generator.models.valid;
+
+import io.avaje.jsonb.Json;
+
+@Json.Import(MyThrowable.class)
+public class MyThrowable extends IllegalArgumentException {
+
+  public MyThrowable(String message) {
+    super(message);
+  }
+  public MyThrowable(String message, IllegalArgumentException cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
it seems that on JDK 21 there are some slight differences that caused generation to fail.

- adjust generator tests to compile with the current release flag
- fix throwable generation to ensure no from Json is generated