### PR TITLE
Upgrade `ObjectAdapter` to deserialize to long in certain situations

### DIFF
--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -392,7 +392,8 @@ final class BasicTypeAdapters {
         case STRING:
           return this.stringAdapter.fromJson(reader);
         case NUMBER:
-          return this.doubleAdapter.fromJson(reader);
+          var d = this.doubleAdapter.fromJson(reader);
+          return (d % 1 == 0) ? d.intValue() : d;
         case BOOLEAN:
           return this.booleanAdapter.fromJson(reader);
         case NULL:

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -393,7 +393,7 @@ final class BasicTypeAdapters {
           return this.stringAdapter.fromJson(reader);
         case NUMBER:
           var d = this.doubleAdapter.fromJson(reader);
-          return (d % 1 == 0) ? d.intValue() : d;
+          return (d % 1 == 0) ? d.longValue() : d;
         case BOOLEAN:
           return this.booleanAdapter.fromJson(reader);
         case NULL:


### PR DESCRIPTION
Currently, unknown Number Types are serialized to double, which may cause issues for those expecting a non-decimal number.