### PR TITLE
Fix Mixins/AdapterName Generation

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AdapterName.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AdapterName.java
@@ -9,22 +9,23 @@ final class AdapterName {
   final String fullName;
 
   AdapterName(TypeElement origin) {
-    String originName = origin.getQualifiedName().toString();
-    String name = origin.getSimpleName().toString();
-    String originPackage = Util.packageOf(originName);
-    if (origin.getNestingKind().isNested()) {
-      String parent = Util.shortName(originPackage);
-      originPackage = Util.packageOf(originPackage);
-      shortName = parent + "$" + name;
-    } else {
-      shortName = name;
-    }
+    String originPackage = APContext.elements().getPackageOf(origin).toString();
+    var name = shortName(origin);
+    shortName = name.substring(0, name.length() - 1);
     if ("".equals(originPackage)) {
       this.adapterPackage = "jsonb";
     } else {
       this.adapterPackage = ProcessingContext.isImported(origin) ? originPackage + ".jsonb" : originPackage;
     }
     this.fullName = adapterPackage + "." + shortName + "JsonAdapter";
+  }
+
+  private String shortName(TypeElement origin) {
+    var sb = new StringBuilder();
+    if (origin.getNestingKind().isNested()) {
+      sb.append(shortName((TypeElement) origin.getEnclosingElement()));
+    }
+    return sb.append(Util.shortName(origin.getSimpleName().toString())).append("$").toString();
   }
 
   String shortName() {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -239,7 +239,7 @@ public final class JsonbProcessor extends AbstractProcessor {
     for (final TypeMirror importType : importPrism.value()) {
       // if imported by mixin annotation skip
       if (mixInImports.contains(importType.toString())) {
-        return;
+        continue;
       }
       writeAdapterForImportedType(asTypeElement(importType), implementationType(importPrism));
     }


### PR DESCRIPTION
- fix mixins stopping multi imports
- fix adapter generation to have all enclosingTypes in the name
- adds validation to mixins such that access modifers must match the target class