### PR TITLE
Writes a file to signal the generator's presence

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -39,10 +39,11 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-inject</artifactId>
-      <version>9.12</version>
+      <version>10.0-RC9</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
+
 
     <dependency>
       <groupId>io.avaje</groupId>
@@ -50,7 +51,13 @@
       <version>2.0-RC3</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-inject-generator</artifactId>
+      <version>10.0-RC9</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
     <!-- test dependencies -->
 
     <dependency>

--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -11,7 +11,7 @@
   <name>jsonb generator</name>
   <description>annotation processor generating source code json adapters for avaje-jsonb</description>
   <properties>
-    <avaje.prisms.version>1.27</avaje.prisms.version>
+    <avaje.prisms.version>1.28</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -61,10 +61,16 @@ public final class JsonbProcessor extends AbstractProcessor {
     try {
 
       var file = APContext.getBuildResource("avaje-processors.txt");
-      var addition =
-          file.toFile().exists()
-              ? Files.lines(file).distinct().collect(joining("\n")) + "\navaje-jsonb-generator"
-              : "avaje-jsonb-generator";
+      var addition = new StringBuilder();
+      if (file.toFile().exists()) {
+        var result =
+            Stream.concat(Files.lines(file), Stream.of("avaje-jsonb-generator"))
+                .distinct()
+                .collect(joining("\n"));
+        addition.append(result);
+      } else {
+        addition.append("avaje-jsonb-generator");
+      }
       Files.writeString(file, addition, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
     } catch (IOException e) {
       // not an issue worth failing over

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -18,6 +18,7 @@ import io.avaje.prism.GenerateModuleInfoReader;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -57,8 +58,8 @@ public final class JsonbProcessor extends AbstractProcessor {
     // write a note in target so that other apts can know inject is running
     try {
 
-      var file = APContext.getBuildResource("avaje-processors/avaje-jsonb-generator");
-      Files.writeString(file, "avaje-inject-generator initialized");
+      var file = APContext.getBuildResource("avaje-processors.txt");
+      Files.writeString(file, "avaje-jsonb-generator\n", StandardOpenOption.CREATE, StandardOpenOption.APPEND);
     } catch (IOException e) {
       // not an issue worth failing over
     }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -16,6 +16,8 @@ import javax.lang.model.util.ElementFilter;
 import io.avaje.prism.GenerateAPContext;
 import io.avaje.prism.GenerateModuleInfoReader;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
@@ -59,7 +61,11 @@ public final class JsonbProcessor extends AbstractProcessor {
     try {
 
       var file = APContext.getBuildResource("avaje-processors.txt");
-      Files.writeString(file, "avaje-jsonb-generator\n", StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+      var addition =
+          file.toFile().exists()
+              ? Files.lines(file).distinct().collect(joining("\n")) + "\navaje-jsonb-generator"
+              : "avaje-jsonb-generator";
+      Files.writeString(file, addition, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
     } catch (IOException e) {
       // not an issue worth failing over
     }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -17,6 +17,7 @@ import io.avaje.prism.GenerateAPContext;
 import io.avaje.prism.GenerateModuleInfoReader;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -53,6 +54,14 @@ public final class JsonbProcessor extends AbstractProcessor {
     super.init(processingEnv);
     ProcessingContext.init(processingEnv);
     this.componentWriter = new SimpleComponentWriter(metaData);
+    // write a note in target so that other apts can know inject is running
+    try {
+
+      var file = APContext.getBuildResource("avaje-processors/avaje-jsonb-generator");
+      Files.writeString(file, "avaje-inject-generator initialized");
+    } catch (IOException e) {
+      // not an issue worth failing over
+    }
   }
 
   /**

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -59,14 +59,12 @@ public final class JsonbProcessor extends AbstractProcessor {
     this.componentWriter = new SimpleComponentWriter(metaData);
     // write a note in target so that other apts can know inject is running
     try {
-
       var file = APContext.getBuildResource("avaje-processors.txt");
       var addition = new StringBuilder();
       if (file.toFile().exists()) {
-        var result =
-            Stream.concat(Files.lines(file), Stream.of("avaje-jsonb-generator"))
-                .distinct()
-                .collect(joining("\n"));
+        var result = Stream.concat(Files.lines(file), Stream.of("avaje-jsonb-generator"))
+          .distinct()
+          .collect(joining("\n"));
         addition.append(result);
       } else {
         addition.append("avaje-jsonb-generator");
@@ -116,30 +114,24 @@ public final class JsonbProcessor extends AbstractProcessor {
       final var type = typeElement.getQualifiedName().toString();
       if (CustomAdapterPrism.getInstanceOn(typeElement).isGeneric()) {
         ElementFilter.fieldsIn(typeElement.getEnclosedElements()).stream()
-            .filter(isStaticFactory())
-            .findFirst()
-            .ifPresentOrElse(
-                x -> {},
-                () ->
-                    logError(
-                        typeElement,
-                        "Generic adapters require a public static JsonAdapter.Factory FACTORY field"));
+          .filter(isStaticFactory())
+          .findFirst()
+          .ifPresentOrElse(
+            x -> {},
+            () -> logError(typeElement, "Generic adapters require a public static JsonAdapter.Factory FACTORY field"));
 
         metaData.addFactory(type);
       } else {
         ElementFilter.constructorsIn(typeElement.getEnclosedElements()).stream()
-            .filter(m -> m.getModifiers().contains(Modifier.PUBLIC))
-            .filter(m -> m.getParameters().size() == 1)
-            .map(m -> m.getParameters().get(0).asType().toString())
-            .map(Util::trimAnnotations)
-            .filter("io.avaje.jsonb.Jsonb"::equals)
-            .findAny()
-            .ifPresentOrElse(
-                x -> {},
-                () ->
-                    logError(
-                        typeElement,
-                        "Non-Generic adapters must have a public constructor with a single Jsonb parameter"));
+          .filter(m -> m.getModifiers().contains(Modifier.PUBLIC))
+          .filter(m -> m.getParameters().size() == 1)
+          .map(m -> m.getParameters().get(0).asType().toString())
+          .map(Util::trimAnnotations)
+          .filter("io.avaje.jsonb.Jsonb"::equals)
+          .findAny()
+          .ifPresentOrElse(
+            x -> {},
+            () -> logError(typeElement, "Non-Generic adapters must have a public constructor with a single Jsonb parameter"));
 
         metaData.add(type);
       }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -78,20 +78,8 @@ final class ProcessingContext {
   }
 
   private static boolean buildPluginAvailable() {
-    return resourceExists("target/avaje-plugin-exists.txt")
-      || resourceExists("build/avaje-plugin-exists.txt");
-  }
-
-  private static boolean resourceExists(String relativeName) {
     try {
-      final String resource =
-        filer()
-          .getResource(StandardLocation.CLASS_OUTPUT, "", relativeName)
-          .toUri()
-          .toString()
-          .replaceFirst("/target/classes", "")
-          .replaceFirst("/build/classes/java/main", "");
-      return Paths.get(new URI(resource)).toFile().exists();
+      return APContext.getBuildResource("avaje-plugin-exists.txt").toFile().exists();
     } catch (final Exception e) {
       return false;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <spi.version>2.0</spi.version>
+    <spi.version>2.1</spi.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Currently, the only way for annotation processors to directly communicate with each other and maven plugins is by writing files and reading them.

Using `Elements` or `Class.forName` to detect other running processors is also unreliable.

This PR enhances the generator to write a marker in `target/avaje-processors.txt` that other processors and tools can pick up.

relies on https://github.com/avaje/avaje-prisms/pull/69