### PR TITLE
Dependabot Grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,19 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  open-pull-requests-limit: 10
-  groups:
-      dev-deps:
-        dependency-type: "development"
-      prod-deps:
-        dependency-type: "production"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        patterns:
+        - "*"
+    labels:
+      - "dependencies"
+    target-branch: "master"
 
-- package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Now dependabot should create a single PR for all the dependencies. [Example PR](https://github.com/SentryMan/avaje-javalin-api-example/pull/50)