### PR TITLE
Add InetAddressAdapter for serialization of all InetAddress variations

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/inetaddress/MyInetAddress.java
+++ b/blackbox-test/src/main/java/org/example/customer/inetaddress/MyInetAddress.java
@@ -1,0 +1,16 @@
+package org.example.customer.inetaddress;
+
+import io.avaje.jsonb.Json;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+
+@Json
+public record MyInetAddress(
+  Inet4Address ipv4,
+  Inet6Address ipv6,
+  InetAddress ipv4Generic,
+  InetAddress ipv6Generic
+) {
+}

--- a/blackbox-test/src/test/java/org/example/customer/inetaddress/MyInetAddressTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/inetaddress/MyInetAddressTest.java
@@ -1,0 +1,34 @@
+package org.example.customer.inetaddress;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyInetAddressTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<MyInetAddress> jsonType = jsonb.type(MyInetAddress.class);
+
+  @Test
+  void toJson_fromJson() throws IOException {
+
+    MyInetAddress myInetAddress = new MyInetAddress(
+      (Inet4Address) InetAddress.getByName("165.124.194.133"),
+      (Inet6Address) InetAddress.getByName("1985:5b4d:9a9e:babc:5a1d:b44e:9942:07b0"),
+      InetAddress.getByName("165.124.194.133"),
+      InetAddress.getByName("1985:5b4d:9a9e:babc:5a1d:b44e:9942:07b0")
+    );
+
+    String asJson = jsonType.toJson(myInetAddress);
+    MyInetAddress fromJson = jsonType.fromJson(asJson);
+
+    assertThat(fromJson).isEqualTo(myInetAddress);
+  }
+}

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -49,6 +49,8 @@ final class BasicTypeAdapters {
         if (type == URL.class) return new UrlAdapter().nullSafe();
         if (type == URI.class) return new UriAdapter().nullSafe();
         if (type == InetAddress.class) return new InetAddressAdapter().nullSafe();
+        if (type == Inet4Address.class) return new InetAddressAdapter().nullSafe();
+        if (type == Inet6Address.class) return new InetAddressAdapter().nullSafe();
         if (type == StackTraceElement.class) return new StackTraceElementAdapter().nullSafe();
         if (type == Object.class) return new ObjectJsonAdapter(jsonb).nullSafe();
         if (type == Throwable.class) return new ThrowableAdapter(jsonb).nullSafe();

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -18,10 +18,7 @@ package io.avaje.jsonb.core;
 import io.avaje.jsonb.*;
 
 import java.lang.reflect.Type;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.net.*;
 import java.util.*;
 
 import static java.util.Objects.requireNonNull;
@@ -51,6 +48,7 @@ final class BasicTypeAdapters {
         if (type == UUID.class) return new UuidAdapter().nullSafe();
         if (type == URL.class) return new UrlAdapter().nullSafe();
         if (type == URI.class) return new UriAdapter().nullSafe();
+        if (type == InetAddress.class) return new InetAddressAdapter().nullSafe();
         if (type == StackTraceElement.class) return new StackTraceElementAdapter().nullSafe();
         if (type == Object.class) return new ObjectJsonAdapter(jsonb).nullSafe();
         if (type == Throwable.class) return new ThrowableAdapter(jsonb).nullSafe();
@@ -114,6 +112,27 @@ final class BasicTypeAdapters {
     @Override
     public String toString() {
       return "JsonAdapter(URI)";
+    }
+  }
+
+  private static final class InetAddressAdapter implements JsonAdapter<InetAddress> {
+    @Override
+    public InetAddress fromJson(JsonReader reader) {
+      try {
+        return InetAddress.getByName(reader.readString());
+      } catch (UnknownHostException e) {
+        throw new JsonDataException(e);
+      }
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, InetAddress value) {
+      writer.value(value.getHostAddress());
+    }
+
+    @Override
+    public String toString() {
+      return "JsonAdapter(InetAddress)";
     }
   }
 


### PR DESCRIPTION
Perhaps adding a usage for valid IPv4 and IPv6 serialization/de-serialization, in blackbox-test, would be desired.