### PR TITLE
Faster jackson defaults

### DIFF
--- a/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonAdapter.java
+++ b/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonAdapter.java
@@ -123,7 +123,6 @@ public class JacksonAdapter implements JsonStreamAdapter {
     this(false, false, false, new JsonFactory());
   }
 
-
   public JacksonAdapter(JsonFactory factory) {
     this(false, false, false, factory);
   }


### PR DESCRIPTION
Faster Jackson default settings
By default Jackson does not enable faster features to ensure 100% backwards compatibility. They should be safe and are already in use by many projects.

Note that `USE_FAST_DOUBLE_WRITER` has been ported to Java 20 and so has been left out. Maybe something for the avaje native json to consider if not already (use built-in instead of custom)?