### PR TITLE
Fix Repeatable Annotation Name Collision

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Constants.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Constants.java
@@ -6,7 +6,7 @@ final class Constants {
   static final String JSONB = "io.avaje.jsonb.Jsonb";
   static final String JSON = "io.avaje.jsonb.Json";
   static final String JSON_IMPORT = "io.avaje.jsonb.Json.Import";
-  static final String JSON_IMPORT_LIST = "io.avaje.jsonb.Json.Import.List";
+  static final String JSON_IMPORT_LIST = "io.avaje.jsonb.Json.Import.Imports";
   static final String JSON_MIXIN = "io.avaje.jsonb.Json.MixIn";
   static final String IOEXCEPTION = "java.io.IOException";
   static final String METHODHANDLE = "java.lang.invoke.MethodHandle";

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -245,7 +245,7 @@ public final class JsonbProcessor extends AbstractProcessor {
 
   private void writeAdaptersForImportedList(Set<? extends Element> imported) {
     imported.stream()
-      .flatMap(e -> ImportListPrism.getInstanceOn(e).value().stream())
+      .flatMap(e -> ImportsPrism.getInstanceOn(e).value().stream())
       .forEach(this::addImported);
   }
 

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
@@ -1,7 +1,7 @@
 @GeneratePrism(io.avaje.jsonb.CustomAdapter.class)
 @GeneratePrism(io.avaje.jsonb.Json.class)
 @GeneratePrism(io.avaje.jsonb.Json.Import.class)
-@GeneratePrism(value = io.avaje.jsonb.Json.Import.List.class, name = "ImportListPrism")
+@GeneratePrism(io.avaje.jsonb.Json.Import.Imports.class)
 @GeneratePrism(io.avaje.jsonb.Json.Alias.class)
 @GeneratePrism(io.avaje.jsonb.Json.Creator.class)
 @GeneratePrism(io.avaje.jsonb.Json.Ignore.class)

--- a/jsonb/src/main/java/io/avaje/jsonb/Json.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Json.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import io.avaje.jsonb.Json.Import.List;
+import io.avaje.jsonb.Json.Import.Imports;
 
 /**
  * Marks a type for JSON support.
@@ -73,7 +73,7 @@ public @interface Json {
    * }</pre>
    */
   @Retention(SOURCE)
-  @Repeatable(List.class)
+  @Repeatable(Imports.class)
   @Target({TYPE, PACKAGE, MODULE})
   @interface Import {
 
@@ -96,7 +96,7 @@ public @interface Json {
      */
     @Retention(SOURCE)
     @Target({TYPE, PACKAGE, MODULE})
-    @interface List {
+    @interface Imports {
 
       Import[] value();
     }


### PR DESCRIPTION
When using JDK 23+ module imports, the `List` type from `java.base`  and `io.avaje.jsonb` have a name collision.

```java
import module java.base;
import module io.avaje.jsonb;

public class Example {

  void main() {
    List.of(); // this fails to resolve the import
  }
}
```