### PR TITLE
[json-node] Add extract() methods to assist filtering and mapping

### DIFF
--- a/json-node/.editorconfig
+++ b/json-node/.editorconfig
@@ -1,0 +1,12 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+spaces_around_operators = true

--- a/json-node/pom.xml
+++ b/json-node/pom.xml
@@ -14,6 +14,12 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-json</artifactId>
       <version>3.0-RC1</version>

--- a/json-node/src/main/java/io/avaje/json/node/JsonArray.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonArray.java
@@ -3,6 +3,7 @@ package io.avaje.json.node;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
@@ -65,6 +66,13 @@ public final class JsonArray implements JsonNode {
    */
   public List<JsonNode> elements() {
     return children;
+  }
+
+  /**
+   * Return the stream of child elements.
+   */
+  public Stream<JsonNode> stream() {
+    return children.stream();
   }
 
   /**

--- a/json-node/src/main/java/io/avaje/json/node/JsonNode.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNode.java
@@ -1,26 +1,120 @@
 package io.avaje.json.node;
 
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the code JSON types.
+ */
 public interface JsonNode {
+
+  /**
+   * The types for JsonNode.
+   */
+  enum Type {
+    ARRAY(true, false),
+    OBJECT(false, true),
+    NULL(),
+    BOOLEAN(),
+    STRING(),
+    NUMBER(true),
+    ;
+    // BINARY,
+    // MISSING,
+    // POJO
+    private final boolean value;
+    private final boolean numberType;
+    private final boolean arrayType;
+    private final boolean objectType;
+
+    Type() {
+      this(true, false, false, false);
+    }
+
+    Type(boolean numberType) {
+      this(true, numberType, false, false);
+    }
+
+    Type(boolean arrayType, boolean objectType) {
+      this(false, false, arrayType, objectType);
+    }
+
+    Type(boolean value, boolean numberType, boolean arrayType, boolean objectType) {
+      this.value = value;
+      this.numberType = numberType;
+      this.arrayType = arrayType;
+      this.objectType = objectType;
+    }
+
+    public boolean isValue() {
+      return value;
+    }
+
+    public boolean isNumber() {
+      return numberType;
+    }
+
+    public boolean isArray() {
+      return arrayType;
+    }
+
+    public boolean isObject() {
+      return objectType;
+    }
+  }
 
   /**
    * Return the type of the node.
    */
   Type type();
 
+  /**
+   * Return a text representation of the node.
+   */
   String text();
 
   /**
-   * The types for JsonNode.
+   * Find a node given a path using dot notation.
+   * @param path The path in dot notation
+   * @return The found node or null
    */
-  enum Type {
-    NULL,
-    ARRAY,
-    OBJECT,
-    BOOLEAN,
-    STRING,
-    NUMBER,
-    // BINARY,
-    // MISSING,
-    // POJO
+  @Nullable
+  default JsonNode find(String path) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the text from the node at the given path.
+   */
+  @Nullable
+  default String extract(String path) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the text from the given path if present or the given default value.
+   */
+  default String extract(String path, String defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the long from the given path if present or the given default value.
+   */
+  default long extract(String path, long defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the int from the given path if present or the given default value.
+   */
+  default Number extract(String path, Number defaultValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the boolean from the given path if present or the given default value.
+   */
+  default boolean extract(String path, boolean defaultValue) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/json-node/src/main/java/io/avaje/json/node/JsonObject.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonObject.java
@@ -1,9 +1,11 @@
 package io.avaje.json.node;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,6 +13,8 @@ import static java.util.Objects.requireNonNull;
  * JSON Object type.
  */
 public final class JsonObject implements JsonNode {
+
+  private static final Pattern PATH_PATTERN = Pattern.compile("\\.");
 
   private final Map<String, JsonNode> children;
 
@@ -87,8 +91,98 @@ public final class JsonObject implements JsonNode {
     return this;
   }
 
-  public Optional<JsonNode> get(String key) {
-    return Optional.ofNullable(children.get(key));
+  /**
+   * Add a String value.
+   */
+  public JsonObject add(String key, String value) {
+    return add(key, JsonString.of(value));
   }
 
+  /**
+   * Add a boolean value.
+   */
+  public JsonObject add(String key, boolean value) {
+    return add(key, JsonBoolean.of(value));
+  }
+
+  /**
+   * Add a int value.
+   */
+  public JsonObject add(String key, int value) {
+    return add(key, JsonInteger.of(value));
+  }
+
+  /**
+   * Add a long value.
+   */
+  public JsonObject add(String key, long value) {
+    return add(key, JsonLong.of(value));
+  }
+
+  /**
+   * Return the direct element at the given path throwing IllegalArgumentException
+   * if it is missing.
+   *
+   * @param key The child key that must exist.
+   * @return The child node.
+   */
+  public JsonNode get(String key) {
+    final var node = children.get(key);
+    if (node == null) {
+      throw new IllegalArgumentException("Node not present for " + key);
+    }
+    return node;
+  }
+
+  @Nullable
+  @Override
+  public JsonNode find(String path) {
+    final String[] paths = PATH_PATTERN.split(path, 2);
+    final JsonNode child = children.get(paths[0]);
+    if (child == null || paths.length == 1) {
+      return child;
+    }
+    if (child instanceof JsonObject) {
+      JsonObject co = (JsonObject) child;
+      return co.find(paths[1]);
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String extract(String path) {
+    final var node = find(path);
+    return node == null ? null : node.text();
+  }
+
+  @Override
+  public String extract(String path, String defaultValue) {
+    final var name = find(path);
+    return name == null ? defaultValue : name.text();
+  }
+
+  @Override
+  public long extract(String path, long defaultValue) {
+    final var node = find(path);
+    return !(node instanceof JsonNumber)
+      ? defaultValue
+      : ((JsonNumber) node).longValue();
+  }
+
+  @Override
+  public Number extract(String path, Number defaultValue) {
+    final var node = find(path);
+    return !(node instanceof JsonNumber)
+      ? defaultValue
+      : ((JsonNumber) node).numberValue();
+  }
+
+  @Override
+  public boolean extract(String path, boolean defaultValue) {
+    final var node = find(path);
+    return !(node instanceof JsonBoolean)
+      ? defaultValue
+      : ((JsonBoolean) node).value();
+  }
 }

--- a/json-node/src/main/java/module-info.java
+++ b/json-node/src/main/java/module-info.java
@@ -2,5 +2,6 @@ module io.avaje.json.node {
 
   exports io.avaje.json.node;
 
+  requires transitive org.jspecify;
   requires transitive io.avaje.json;
 }

--- a/json-node/src/test/java/io/avaje/json/node/JsonArrayTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/JsonArrayTest.java
@@ -1,0 +1,72 @@
+package io.avaje.json.node;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonArrayTest {
+
+  String input =
+    "{\n" +
+    "    \"firstName\": \"John\",\n" +
+    "    \"lastName\": \"doe\",\n" +
+    "    \"age\": 26,\n" +
+    "    \"address\": {\n" +
+    "        \"streetAddress\": \"naist street\",\n" +
+    "        \"city\": \"Nara\",\n" +
+    "        \"postalCode\": \"630-0192\"\n" +
+    "    },\n" +
+    "    \"phoneNumbers\": [\n" +
+    "        {\n" +
+    "            \"type\": \"iPhone\",\n" +
+    "            \"number\": \"0123-4567-8888\"\n" +
+    "        },\n" +
+    "        {\n" +
+    "            \"type\": \"home\",\n" +
+    "            \"number\": \"0123-4567-8910\"\n" +
+    "        },\n" +
+    "        {\n" +
+    "            \"type\": \"home\",\n" +
+    "            \"number\": \"563-4567-8910\"\n" +
+    "        }\n" +
+    "    ]\n" +
+    "}";
+
+  static final JsonNodeAdapter node = JsonNodeAdapter.builder().build();
+
+  static final JsonArray basicArray = JsonArray.create()
+    .add(JsonInteger.of(42))
+    .add(JsonString.of("foo"));
+
+  @Test
+  void streamFilter() {
+
+    JsonObject top = node.fromJson(JsonObject.class, input);
+    JsonArray phoneNumbers = (JsonArray)top.get("phoneNumbers");
+
+    List<String> result =
+      phoneNumbers.stream()
+      .filter(n -> "home".equals(n.extract("type")))
+      .map(n -> n.extract("number"))
+      .collect(Collectors.toList());
+
+    assertThat(result).hasSize(2);
+  }
+
+  @Test
+  void type() {
+    assertThat(basicArray.type()).isEqualTo(JsonNode.Type.ARRAY);
+    assertThat(basicArray.type().isArray()).isTrue();
+    assertThat(basicArray.type().isObject()).isFalse();
+    assertThat(basicArray.type().isValue()).isFalse();
+  }
+
+  @Test
+  void text() {
+    assertThat(JsonArray.create().text()).isEqualTo("[]");
+    assertThat(basicArray.text()).isEqualTo("[42, foo]");
+  }
+}


### PR DESCRIPTION
```java
    JsonArray phoneNumbers = ...;

    List<String> result =
      phoneNumbers.stream()
        .filter(n -> "home".equals(n.extract("type")))
        .map(n -> n.extract("number"))
        .collect(Collectors.toList());
```

extract() can take a dot notation path like `person.name` (so not JSONPath)
```java

    var node = JsonObject.create()
      .add("person", JsonObject.create().add("name", "myName").add("type", "doo").add("active", true))
      .add("address", JsonObject.create().add("size", 42).add("junk", 99L).add("other", JsonObject.create().add("deep", "one")));

    JsonNode name = node.find("name");
    assertThat(name).isNull();

    JsonNode personName = node.find("person.name");
    assertThat(personName).isNotNull();
    assertThat(personName.text()).isEqualTo("myName");

    assertThat(node.extract("person.name")).isEqualTo("myName");
    assertThat(node.extract("person.active")).isEqualTo("true");
    assertThat(node.extract("person.active", false)).isEqualTo(true);
    assertThat(node.extract("person.missing", false)).isEqualTo(false);

    assertThat(node.extract("address.size", -1)).isEqualTo(42);

    assertThat(node.extract("address.other.deep")).isEqualTo("one");

```