### PR TITLE
[json-node] Add extractNode() and empty() helpers for JsonArray and JsonObject

### DIFF
--- a/json-node/src/main/java/io/avaje/json/node/JsonArray.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonArray.java
@@ -12,7 +12,16 @@ import static java.util.Objects.requireNonNull;
  */
 public final class JsonArray implements JsonNode {
 
+  private static final JsonArray EMPTY = new JsonArray(Collections.emptyList());
+
   private final List<JsonNode> children;
+
+  /**
+   * Create an empty immutable JsonArray.
+   */
+  public static JsonArray empty() {
+    return EMPTY;
+  }
 
   /**
    * Create a new JsonArray that can be added to.

--- a/json-node/src/main/java/io/avaje/json/node/JsonNode.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNode.java
@@ -82,6 +82,7 @@ public /*sealed*/ interface JsonNode
 
   /**
    * Find a node given a path using dot notation.
+   *
    * @param path The path in dot notation
    * @return The found node or null
    */
@@ -92,37 +93,67 @@ public /*sealed*/ interface JsonNode
 
   /**
    * Extract the text from the node at the given path.
+   *
+   * @throws IllegalArgumentException When the given path is missing.
    */
-  @Nullable
   default String extract(String path) {
     throw new UnsupportedOperationException();
   }
 
   /**
    * Extract the text from the given path if present or the given default value.
+   *
+   * @param missingValue The value to use when the path is missing.
    */
-  default String extract(String path, String defaultValue) {
+  default String extract(String path, String missingValue) {
     throw new UnsupportedOperationException();
   }
 
   /**
    * Extract the long from the given path if present or the given default value.
+   *
+   * @param missingValue The value to use when the path is missing.
    */
-  default long extract(String path, long defaultValue) {
+  default long extract(String path, long missingValue) {
     throw new UnsupportedOperationException();
   }
 
   /**
    * Extract the int from the given path if present or the given default value.
+   *
+   * @param missingValue The value to use when the path is missing.
    */
-  default Number extract(String path, Number defaultValue) {
+  default Number extract(String path, Number missingValue) {
     throw new UnsupportedOperationException();
   }
 
   /**
    * Extract the boolean from the given path if present or the given default value.
+   *
+   * @param missingValue The value to use when the path is missing.
    */
-  default boolean extract(String path, boolean defaultValue) {
+  default boolean extract(String path, boolean missingValue) {
     throw new UnsupportedOperationException();
   }
+
+  /**
+   * Extract the node from the given path if present or throw IllegalArgumentException
+   * if it is missing.
+   *
+   * @throws IllegalArgumentException When the given path is missing.
+   */
+  default JsonNode extractNode(String path) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Extract the node from the given path if present or the given default value.
+   *
+   * @param missingValue The node to use when the path is missing.
+   * @return The node for the given path.
+   */
+  default JsonNode extractNode(String path, JsonNode missingValue) {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/json-node/src/main/java/io/avaje/json/node/JsonObject.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonObject.java
@@ -186,16 +186,16 @@ public final class JsonObject implements JsonNode {
   }
 
   @Override
-  public String extract(String path, String missing) {
+  public String extract(String path, String missingValue) {
     final var name = find(path);
-    return name == null ? missing : name.text();
+    return name == null ? missingValue : name.text();
   }
 
   @Override
-  public long extract(String path, long missing) {
+  public long extract(String path, long missingValue) {
     final var node = find(path);
     return !(node instanceof JsonNumber)
-      ? missing
+      ? missingValue
       : ((JsonNumber) node).longValue();
   }
 
@@ -208,10 +208,10 @@ public final class JsonObject implements JsonNode {
   }
 
   @Override
-  public boolean extract(String path, boolean missing) {
+  public boolean extract(String path, boolean missingValue) {
     final var node = find(path);
     return !(node instanceof JsonBoolean)
-      ? missing
+      ? missingValue
       : ((JsonBoolean) node).value();
   }
 
@@ -225,8 +225,8 @@ public final class JsonObject implements JsonNode {
   }
 
   @Override
-  public JsonNode extractNode(String path, JsonNode missing) {
+  public JsonNode extractNode(String path, JsonNode missingValue) {
     final var node = find(path);
-    return node != null ? node : missing;
+    return node != null ? node : missingValue;
   }
 }

--- a/json-node/src/test/java/io/avaje/json/node/ExtractNodeTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/ExtractNodeTest.java
@@ -1,0 +1,104 @@
+package io.avaje.json.node;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ExtractNodeTest {
+
+  static final String content =
+    "  {\n" +
+    "    \"people\": [\n" +
+    "      {\n" +
+    "        \"type\": \"contact\",\n" +
+    "        \"person\": {\n" +
+    "          \"firstName\": \"Aa\",\n" +
+    "          \"lastName\": \"ALast\"\n" +
+    "          \"other\": \"AOther\"\n" +
+    "        }\n" +
+    "      },\n" +
+    "      {\n" +
+    "        \"type\": \"family\",\n" +
+    "        \"person\": {\n" +
+    "          \"firstName\": \"Bb\",\n" +
+    "          \"lastName\": \"Blast\"\n" +
+    "          \"other\": \"BOther\"\n" +
+    "        }\n" +
+    "      },\n" +
+    "      {\n" +
+    "        \"type\": \"family\",\n" +
+    "        \"person\": {\n" +
+    "          \"firstName\": \"Cc\",\n" +
+    "          \"lastName\": \"CLast\"\n" +
+    "        }\n" +
+    "      }\n" +
+    "    ]\n" +
+    "  }";
+
+  static final JsonNodeAdapter node = JsonNodeAdapter.builder().build();
+
+  @Test
+  void extract() {
+
+    JsonObject object = ExtractNodeTest.node.fromJson(JsonObject.class, content);
+    JsonArray arrayWithNestedPerson = (JsonArray) object.get("people");
+
+    List<JsonNode> peopleNodes =
+      arrayWithNestedPerson.stream()
+      .filter(node -> "family".equals(node.extract("type")))
+      .map(node -> node.extractNode("person"))
+      .collect(Collectors.toList());
+
+    assertThat(peopleNodes).hasSize(2);
+    assertThat(peopleNodes.get(0)).isInstanceOf(JsonObject.class);
+
+    List<JsonNode> lastNamesNodes =
+      arrayWithNestedPerson.stream()
+        .filter(node -> "family".equals(node.extract("type")))
+        .map(node -> node.extractNode("person.lastName"))
+        .collect(Collectors.toList());
+
+    assertThat(lastNamesNodes).hasSize(2);
+    assertThat(lastNamesNodes.get(0)).isInstanceOf(JsonString.class);
+
+
+    List<String> missingOther =
+      arrayWithNestedPerson.stream()
+        .filter(node -> "family".equals(node.extract("type")))
+        .map(node -> node.extractNode("person.other", JsonString.of("MISSING!")))
+        .map(JsonNode::text)
+        .collect(Collectors.toList());
+
+    assertThat(missingOther).hasSize(2);
+    assertThat(missingOther).containsExactly("BOther", "MISSING!");
+  }
+
+  @Test
+  void extractMissing_expect_IllegalArgumentException() {
+    JsonObject object = ExtractNodeTest.node.fromJson(JsonObject.class, content);
+
+    assertThatThrownBy(() -> object.extractNode("missing.path.here"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Node not present for missing.path.here");
+  }
+
+  @Test
+  void extractMissing_missing_object() {
+    JsonObject object = ExtractNodeTest.node.fromJson(JsonObject.class, content);
+
+    JsonNode result = object.extractNode("missing.path.here", JsonObject.empty());
+    assertThat(result).isSameAs(JsonObject.empty());
+  }
+
+  @Test
+  void extractMissing_missing_array() {
+    JsonObject object = ExtractNodeTest.node.fromJson(JsonObject.class, content);
+
+    JsonNode result = object.extractNode("missing.path.here", JsonArray.empty());
+    assertThat(result).isSameAs(JsonArray.empty());
+  }
+}


### PR DESCRIPTION
Example `.extractNode("person")`

```java
    JsonArray arrayWithNestedPerson = (JsonArray) object.get("people");

    List<JsonNode> peopleNodes =
      arrayWithNestedPerson.stream()
      .filter(node -> "family".equals(node.extract("type")))
      .map(node -> node.extractNode("person")). // <!-- HERE ... .extractNode("person")
      .collect(Collectors.toList());

```