### PR TITLE
[json-node] Make avaje-json-node an optional component for JsonB

### DIFF
--- a/blackbox-test/pom.xml
+++ b/blackbox-test/pom.xml
@@ -31,6 +31,12 @@
       <version>3.0-RC2</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-json-node</artifactId>
+      <version>3.0-RC2</version>
+    </dependency>
+
 <!--    <dependency>-->
 <!--      <groupId>io.avaje</groupId>-->
 <!--      <artifactId>avaje-jsonb-jackson</artifactId>-->

--- a/blackbox-test/src/test/java/org/example/other/JsonNodeAdaptersTest.java
+++ b/blackbox-test/src/test/java/org/example/other/JsonNodeAdaptersTest.java
@@ -1,0 +1,33 @@
+package org.example.other;
+
+import io.avaje.json.node.JsonNode;
+import io.avaje.json.node.JsonObject;
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonNodeAdaptersTest {
+
+  static final Jsonb jsonb = Jsonb.builder().build();
+  static final JsonType<JsonNode> nodeType = jsonb.type(JsonNode.class);
+
+  @Test
+  void test() {
+    var obj = JsonObject.create().add("name", "foo").add("val", 42);
+
+    String asJson = nodeType.toJson(obj);
+    assertThat(asJson).isEqualTo("{\"name\":\"foo\",\"val\":42}");
+
+    String asJson2 = jsonb.toJson(obj);
+    assertThat(asJson2).isEqualTo(asJson);
+
+    JsonNode fromJson = nodeType.fromJson(asJson);
+    assertThat(fromJson).isInstanceOf(JsonObject.class);
+
+    JsonObject objFromJson = (JsonObject) fromJson;
+    assertThat(objFromJson.elements()).containsKeys("name", "val");
+  }
+
+}

--- a/json-node/pom.xml
+++ b/json-node/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-jsonb-parent</artifactId>
-    <version>3.0-RC1</version>
+    <version>3.0-RC2</version>
   </parent>
 
   <artifactId>avaje-json-node</artifactId>
@@ -27,6 +27,13 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-json</artifactId>
       <version>3.0-RC1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>3.0-RC1</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/json-node/src/main/java/io/avaje/json/node/adapter/JsonNodeComponent.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/JsonNodeComponent.java
@@ -1,0 +1,34 @@
+package io.avaje.json.node.adapter;
+
+import io.avaje.json.JsonAdapter;
+import io.avaje.json.node.JsonNodeAdapter;
+import io.avaje.jsonb.AdapterFactory;
+import io.avaje.jsonb.Jsonb;
+import io.avaje.jsonb.spi.JsonbComponent;
+
+import java.lang.reflect.Type;
+
+/**
+ * Register with JsonB to support the JsonAdapters for JsonNode types.
+ */
+public final class JsonNodeComponent implements JsonbComponent {
+
+  @Override
+  public void register(Jsonb.Builder builder) {
+    builder.add(new JsonBFactory(JsonNodeAdapter.builder().build()));
+  }
+
+  private static final class JsonBFactory implements AdapterFactory {
+
+    private final JsonNodeAdapter nodeAdapter;
+
+    JsonBFactory(JsonNodeAdapter nodeAdapter) {
+      this.nodeAdapter = nodeAdapter;
+    }
+
+    @Override
+    public JsonAdapter<?> create(Type type, Jsonb jsonb) {
+      return nodeAdapter.create(type);
+    }
+  }
+}

--- a/json-node/src/main/java/module-info.java
+++ b/json-node/src/main/java/module-info.java
@@ -4,4 +4,8 @@ module io.avaje.json.node {
 
   requires transitive org.jspecify;
   requires transitive io.avaje.json;
+
+  requires static io.avaje.jsonb;
+  exports io.avaje.json.node.adapter to io.avaje.jsonb;
+  provides io.avaje.jsonb.spi.JsonbComponent with io.avaje.json.node.adapter.JsonNodeComponent;
 }

--- a/json-node/src/main/resources/META-INF/services/io.avaje.jsonb.spi.JsonbExtension
+++ b/json-node/src/main/resources/META-INF/services/io.avaje.jsonb.spi.JsonbExtension
@@ -1,0 +1,1 @@
+io.avaje.json.node.adapter.JsonNodeComponent

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -19,6 +19,12 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-json-node</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
      <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb-inject-plugin</artifactId>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -19,12 +19,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>io.avaje</groupId>
-      <artifactId>avaje-json-node</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
      <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-jsonb-inject-plugin</artifactId>


### PR DESCRIPTION
That is, we need to explicitly include avaje-json-node in the classpath/module path.

When JsonB starts with avaje-json-node present, it will register with JsonB thus support the JsonNode types in JsonB.