### PR TITLE
[json-core] Add SimpleMapper API to core to make it easier for reading/writing simple Maps, Lists etc

### DIFF
--- a/json-core/src/main/java/io/avaje/json/core/BasicObjectAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/core/BasicObjectAdapter.java
@@ -7,7 +7,7 @@ import io.avaje.json.JsonWriter;
 import java.util.List;
 import java.util.Map;
 
-final class BasicObjectAdapter implements JsonAdapter<Object>  {
+final class BasicObjectAdapter implements JsonAdapter<Object>, CoreTypes.CoreAdapters  {
 
   private final JsonAdapter<String> stringAdapter;
   private final JsonAdapter<Double> doubleAdapter;
@@ -25,6 +25,21 @@ final class BasicObjectAdapter implements JsonAdapter<Object>  {
     this.booleanAdapter = CoreTypes.create(Boolean.class);
     this.listAdapter = CoreTypes.createList(this);
     this.mapAdapter = CoreTypes.createMap(this);
+  }
+
+  @Override
+  public JsonAdapter<Object> objectAdapter() {
+    return this;
+  }
+
+  @Override
+  public JsonAdapter<List<Object>> listAdapter() {
+    return listAdapter;
+  }
+
+  @Override
+  public JsonAdapter<Map<String, Object>> mapAdapter() {
+    return mapAdapter;
   }
 
   @Override

--- a/json-core/src/main/java/io/avaje/json/core/CoreTypes.java
+++ b/json-core/src/main/java/io/avaje/json/core/CoreTypes.java
@@ -98,7 +98,7 @@ public final class CoreTypes {
    * types of: String, Integer, Long, Double, Boolean plus List and Map
    * of those types.
    */
-  public static JsonAdapter<Object> createBasicObject() {
+  public static CoreAdapters createCoreAdapters() {
     return new BasicObjectAdapter();
   }
 
@@ -121,5 +121,26 @@ public final class CoreTypes {
     public Void fromJson(JsonReader reader) {
       throw new UnsupportedOperationException();
     }
+  }
+
+  /**
+   * The basic JsonAdapter types.
+   */
+  public interface CoreAdapters {
+
+    /**
+     * Return the Object JsonAdapter.
+     */
+    JsonAdapter<Object> objectAdapter();
+
+    /**
+     * Return the List JsonAdapter.
+     */
+    JsonAdapter<List<Object>> listAdapter();
+
+    /**
+     * Return the Map JsonAdapter.
+     */
+    JsonAdapter<Map<String, Object>> mapAdapter();
   }
 }

--- a/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
@@ -1,0 +1,55 @@
+package io.avaje.json.simple;
+
+import io.avaje.json.core.CoreTypes;
+import io.avaje.json.stream.JsonStream;
+
+import java.util.List;
+import java.util.Map;
+
+final class DSimpleMapper implements SimpleMapper {
+
+  private final Type<Object> objectType;
+  private final Type<Map<String,Object>> mapType;
+  private final Type<List<Object>> listType;
+
+  DSimpleMapper(JsonStream jsonStream, CoreTypes.CoreAdapters adapters) {
+    this.objectType = new DTypeMapper<>(adapters.objectAdapter(), jsonStream);
+    this.mapType = new DTypeMapper<>(adapters.mapAdapter(), jsonStream);
+    this.listType = new DTypeMapper<>(adapters.listAdapter(), jsonStream);
+  }
+
+  @Override
+  public Type<Object> object() {
+    return objectType;
+  }
+
+  @Override
+  public Type<Map<String, Object>> map() {
+    return mapType;
+  }
+
+  @Override
+  public Type<List<Object>> list() {
+    return listType;
+  }
+
+  @Override
+  public String toJson(Object object) {
+    return objectType.toJson(object);
+  }
+
+  @Override
+  public Object fromJson(String json) {
+    return objectType.fromJson(json);
+  }
+
+  @Override
+  public Map<String,Object> fromJsonObject(String json) {
+    return mapType.fromJson(json);
+  }
+
+  @Override
+  public List<Object> fromJsonArray(String json) {
+    return listType.fromJson(json);
+  }
+}

--- a/json-core/src/main/java/io/avaje/json/simple/DSimpleMapperBuilder.java
+++ b/json-core/src/main/java/io/avaje/json/simple/DSimpleMapperBuilder.java
@@ -1,0 +1,22 @@
+package io.avaje.json.simple;
+
+import io.avaje.json.core.CoreTypes;
+import io.avaje.json.stream.JsonStream;
+
+final class DSimpleMapperBuilder implements SimpleMapper.Builder {
+
+  private JsonStream jsonStream;
+
+  @Override
+  public SimpleMapper.Builder jsonStream(JsonStream jsonStream) {
+    this.jsonStream = jsonStream;
+    return this;
+  }
+
+  @Override
+  public SimpleMapper build() {
+    final var stream = jsonStream != null ? jsonStream : JsonStream.builder().build();
+    final var coreAdapters = CoreTypes.createCoreAdapters();
+    return new DSimpleMapper(stream, coreAdapters);
+  }
+}

--- a/json-core/src/main/java/io/avaje/json/simple/DTypeMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/DTypeMapper.java
@@ -1,0 +1,114 @@
+package io.avaje.json.simple;
+
+import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonException;
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
+import io.avaje.json.stream.BufferedJsonWriter;
+import io.avaje.json.stream.BytesJsonWriter;
+import io.avaje.json.stream.JsonStream;
+
+import java.io.*;
+
+final class DTypeMapper<T> implements SimpleMapper.Type<T> {
+
+  private final JsonAdapter<T> adapter;
+  private final JsonStream jsonStream;
+
+  DTypeMapper(JsonAdapter<T> adapter, JsonStream jsonStream) {
+    this.adapter = adapter;
+    this.jsonStream = jsonStream;
+  }
+
+  @Override
+  public T fromJson(JsonReader reader) {
+    return adapter.fromJson(reader);
+  }
+
+  @Override
+  public T fromJson(String content) {
+    try (JsonReader reader = jsonStream.reader(content)) {
+      return adapter.fromJson(reader);
+    }
+  }
+
+  @Override
+  public T fromJson(byte[] content) {
+    try (JsonReader reader = jsonStream.reader(content)) {
+      return adapter.fromJson(reader);
+    }
+  }
+
+  @Override
+  public T fromJson(Reader content) {
+    try (JsonReader reader = jsonStream.reader(content)) {
+      return adapter.fromJson(reader);
+    }
+  }
+
+  @Override
+  public T fromJson(InputStream content) {
+    try (JsonReader reader = jsonStream.reader(content)) {
+      return adapter.fromJson(reader);
+    }
+  }
+
+  @Override
+  public String toJson(T value) {
+    try (BufferedJsonWriter writer = jsonStream.bufferedWriter()) {
+      toJson(value, writer);
+      return writer.result();
+    }
+  }
+
+  @Override
+  public String toJsonPretty(T value) {
+    try (BufferedJsonWriter writer = jsonStream.bufferedWriter()) {
+      writer.pretty(true);
+      toJson(value, writer);
+      return writer.result();
+    }
+  }
+
+  @Override
+  public byte[] toJsonBytes(T value) {
+    try (BytesJsonWriter writer = jsonStream.bufferedWriterAsBytes()) {
+      toJson(value, writer);
+      return writer.result();
+    }
+  }
+
+  @Override
+  public void toJson(T value, JsonWriter writer) {
+    try {
+      adapter.toJson(writer, value);
+    } catch (RuntimeException e) {
+      writer.markIncomplete();
+      throw new JsonException(e);
+    }
+  }
+
+  @Override
+  public void toJson(T value, Writer writer) {
+    try (JsonWriter jsonWriter = jsonStream.writer(writer)) {
+      toJson(value, jsonWriter);
+    }
+  }
+
+  @Override
+  public void toJson(T value, OutputStream outputStream) {
+    try (JsonWriter writer = jsonStream.writer(outputStream)) {
+      toJson(value, writer);
+    }
+    close(outputStream);
+  }
+
+  private void close(Closeable outputStream) {
+    try {
+      outputStream.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Error closing stream", e);
+    }
+  }
+
+}

--- a/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
@@ -1,0 +1,174 @@
+package io.avaje.json.simple;
+
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
+import io.avaje.json.stream.JsonStream;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A mapper for mapping to basic Java types.
+ * <p>
+ * This supports the basic Java types of String, Boolean, Integer, Long, Double and
+ * Maps and List of these.
+ * <p>
+ * For full support with more types and binding to custom types use avaje-jsonb instead.
+ *
+ * <h3>Example</h3>
+ * <pre>{@code
+ *
+ *   static final SimpleMapper simpleMapper = SimpleMapper.builder().build();
+ *
+ *   Map<String, Long> map = new LinkedHashMap<>();
+ *   map.put("one", 45L);
+ *   map.put("two", 93L);
+ *
+ *   String asJson = simpleMapper.toJson(map);
+ *
+ * }</pre>
+ */
+public interface SimpleMapper {
+
+  /**
+   * Create a new builder for SimpleMapper.
+   */
+  static Builder builder() {
+    return new DSimpleMapperBuilder();
+  }
+
+  /**
+   * Return a mapper for Object with more reading/writing options.
+   */
+  Type<Object> object();
+
+  /**
+   * Return a mapper for json OBJECT content with more reading/writing options.
+   */
+  Type<Map<String, Object>> map();
+
+  /**
+   * Return a mapper for json ARRAY content with more reading/writing options.
+   */
+  Type<List<Object>> list();
+
+  /**
+   * Write the object to JSON string.
+   * <p>
+   * For options to write json content to OutputStream, Writer etc
+   * use {@link Type}.
+   *
+   * <pre>{@code
+   *
+   * var list = List.of(42, "hello");
+   *
+   * var asJson = mapper.toJson(list);
+   * }</pre>
+   */
+  String toJson(Object object);
+
+  /**
+   * Read the object from JSON string.
+   */
+  Object fromJson(String json);
+
+  /**
+   * Read a Map from JSON OBJECT string.
+   * <p>
+   * Use {@link #map()} for more reading options.
+   */
+  Map<String, Object> fromJsonObject(String json);
+
+  /**
+   * Read a List from JSON ARRAY string.
+   * <p>
+   * Use {@link #list()} for more reading options.
+   */
+  List<Object> fromJsonArray(String json);
+
+  /**
+   * Build the JsonNodeMapper.
+   */
+  interface Builder {
+
+    /**
+     * Set the default JsonStream to use.
+     * <p>
+     * When not set this defaults to {@code JsonStream.builder().build()}.
+     *
+     * @see JsonStream#builder()
+     */
+    Builder jsonStream(JsonStream jsonStream);
+
+    /**
+     * Build and return the JsonNodeMapper.
+     */
+    SimpleMapper build();
+  }
+
+  /**
+   * Reading and writing with all options such and InputStream, Reader etc.
+   */
+  interface Type<T> {
+
+    /**
+     * Read the return the value from the json content.
+     */
+    T fromJson(String content);
+
+    /**
+     * Read the return the value from the reader.
+     */
+    T fromJson(JsonReader reader);
+
+    /**
+     * Read the return the value from the json content.
+     */
+    T fromJson(byte[] content);
+
+    /**
+     * Read the return the value from the reader.
+     */
+    T fromJson(Reader reader);
+
+    /**
+     * Read the return the value from the inputStream.
+     */
+    T fromJson(InputStream inputStream);
+
+    /**
+     * Return as json string.
+     */
+    String toJson(T value);
+
+    /**
+     * Return as json string in pretty format.
+     */
+    String toJsonPretty(T value);
+
+    /**
+     * Return the value as json content in bytes form.
+     */
+    byte[] toJsonBytes(T value);
+
+    /**
+     * Write to the given writer.
+     */
+    void toJson(T value, JsonWriter writer);
+
+    /**
+     * Write to the given writer.
+     */
+    void toJson(T value, Writer writer);
+
+    /**
+     * Write to the given outputStream.
+     */
+    void toJson(T value, OutputStream outputStream);
+
+  }
+}

--- a/json-core/src/main/java/module-info.java
+++ b/json-core/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module io.avaje.json {
 
   exports io.avaje.json;
+  exports io.avaje.json.simple;
   exports io.avaje.json.stream;
   exports io.avaje.json.view;
   exports io.avaje.json.core to io.avaje.jsonb;

--- a/json-core/src/test/java/io/avaje/json/core/CoreTypesTest.java
+++ b/json-core/src/test/java/io/avaje/json/core/CoreTypesTest.java
@@ -56,8 +56,9 @@ class CoreTypesTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  void createBasicObject() {
-    JsonAdapter<Object> basicObject = CoreTypes.createBasicObject();
+  void createCoreAdapters() {
+    CoreTypes.CoreAdapters coreAdapters = CoreTypes.createCoreAdapters();
+    JsonAdapter<Object> basicObject = coreAdapters.objectAdapter();
 
     Map<String, Object> inner = new LinkedHashMap<>();
     inner.put("nm", "r");

--- a/json-core/src/test/java/io/avaje/json/simple/SimpleMapperTest.java
+++ b/json-core/src/test/java/io/avaje/json/simple/SimpleMapperTest.java
@@ -1,0 +1,58 @@
+package io.avaje.json.simple;
+
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleMapperTest {
+
+  static final SimpleMapper simpleMapper = SimpleMapper.builder().build();
+
+  @Test
+  void mapToJsonFromJson() {
+
+    Map<String, Long> map = new LinkedHashMap<>();
+    map.put("one", 45L);
+    map.put("two", 93L);
+
+    String asJson = simpleMapper.toJson(map);
+    assertThat(asJson).isEqualTo("{\"one\":45,\"two\":93}");
+
+    Map<String, Object> mapFromJson = simpleMapper.fromJsonObject(asJson);
+
+    assertThat(mapFromJson).containsKeys("one", "two");
+    assertThat(mapFromJson.toString()).isEqualTo("{one=45, two=93}");
+
+    Map<String, Object> mapFromJson2 = simpleMapper.map().fromJson(asJson);
+    assertThat(mapFromJson2).isEqualTo(mapFromJson);
+  }
+
+  @Test
+  void arrayToJsonFromJson() {
+
+    Map<String, Long> map0 = new LinkedHashMap<>();
+    map0.put("one", 45L);
+    map0.put("two", 93L);
+
+    Map<String, Long> map1 = new LinkedHashMap<>();
+    map1.put("one", 27L);
+
+    List<Map<String, Long>> list = List.of(map0, map1);
+
+    String asJson = simpleMapper.toJson(list);
+    assertThat(asJson).isEqualTo("[{\"one\":45,\"two\":93},{\"one\":27}]");
+
+    List<Object> listFromJson = simpleMapper.fromJsonArray(asJson);
+
+    assertThat(listFromJson).hasSize(2);
+    assertThat(listFromJson.toString()).isEqualTo("[{one=45, two=93}, {one=27}]");
+
+    List<Object> list2 = simpleMapper.list().fromJson(asJson);
+    assertThat(list2).isEqualTo(listFromJson);
+  }
+}


### PR DESCRIPTION
```java

 static final SimpleMapper simpleMapper = SimpleMapper.builder().build();

  void test() {

    Map<String, Long> map = new LinkedHashMap<>();
    map.put("one", 45L);
    map.put("two", 93L);

    String asJson = simpleMapper.toJson(map);
    assertThat(asJson).isEqualTo("{\"one\":45,\"two\":93}");

    Map<String, Object> mapFromJson = simpleMapper.fromJsonObject(asJson);

    assertThat(mapFromJson).containsKeys("one", "two");
    assertThat(mapFromJson.toString()).isEqualTo("{one=45, two=93}");
  }

```