### PR TITLE
[json-node] JsonNodeMapper add type support for customer JsonAdapters

### DIFF
--- a/json-node/src/main/java/io/avaje/json/node/JsonNode.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNode.java
@@ -110,6 +110,15 @@ public /*sealed*/ interface JsonNode
   }
 
   /**
+   * Extract the int from the given path if present or the given default value.
+   *
+   * @param missingValue The value to use when the path is missing.
+   */
+  default int extract(String path, int missingValue) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Extract the long from the given path if present or the given default value.
    *
    * @param missingValue The value to use when the path is missing.

--- a/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
@@ -40,6 +40,8 @@ public interface JsonNodeMapper {
     return new NodeAdapterBuilder();
   }
 
+  <T> NodeMapper<T> mapper(JsonAdapter<T> customAdapter);
+
   /**
    * Return a NodeMapper for ANY json content.
    * <p>

--- a/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
@@ -40,6 +40,13 @@ public interface JsonNodeMapper {
     return new NodeAdapterBuilder();
   }
 
+  /**
+   * Create a NodeMapper for the specific type given the JsonAdapter.
+   *
+   * @param customAdapter The type specific JsonAdapter to use.
+   * @param <T>           The specific custom type being mapped.
+   * @return The type specific NodeMapper.
+   */
   <T> NodeMapper<T> mapper(JsonAdapter<T> customAdapter);
 
   /**
@@ -82,8 +89,8 @@ public interface JsonNodeMapper {
    * var asJson = mapper.toJson(jsonArray);
    * }</pre>
    *
-   * @see NodeMapper#toJson(JsonNode, OutputStream)
-   * @see NodeMapper#toJson(JsonNode, Writer)
+   * @see NodeMapper#toJson(Object, OutputStream)
+   * @see NodeMapper#toJson(Object, Writer)
    */
   String toJson(JsonNode node);
 

--- a/json-node/src/main/java/io/avaje/json/node/JsonObject.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonObject.java
@@ -206,6 +206,14 @@ public final class JsonObject implements JsonNode {
   }
 
   @Override
+  public int extract(String path, int missingValue) {
+    final var node = find(path);
+    return !(node instanceof JsonNumber)
+      ? missingValue
+      : ((JsonNumber) node).intValue();
+  }
+
+  @Override
   public long extract(String path, long missingValue) {
     final var node = find(path);
     return !(node instanceof JsonNumber)

--- a/json-node/src/main/java/io/avaje/json/node/NodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/NodeMapper.java
@@ -18,7 +18,7 @@ import java.io.Writer;
  * @see JsonNodeMapper#objectMapper()
  * @see JsonNodeMapper#nodeMapper()
  */
-public interface NodeMapper<T extends JsonNode> {
+public interface NodeMapper<T> {
 
   /**
    * Read the return the value from the json content.

--- a/json-node/src/main/java/io/avaje/json/node/adapter/DJsonNodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/DJsonNodeMapper.java
@@ -30,6 +30,11 @@ final class DJsonNodeMapper implements JsonNodeMapper {
   }
 
   @Override
+  public <T> NodeMapper<T> mapper(JsonAdapter<T> customAdapter) {
+    return new DMapper<>(customAdapter, jsonStream);
+  }
+
+  @Override
   public NodeMapper<JsonNode> nodeMapper() {
     return new DMapper<>(nodeAdapter, jsonStream);
   }

--- a/json-node/src/main/java/io/avaje/json/node/adapter/DMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/DMapper.java
@@ -12,7 +12,7 @@ import io.avaje.json.stream.JsonStream;
 
 import java.io.*;
 
-final class DMapper<T extends JsonNode> implements NodeMapper<T> {
+final class DMapper<T> implements NodeMapper<T> {
 
   private final JsonAdapter<T> adapter;
   private final JsonStream jsonStream;

--- a/json-node/src/test/java/io/avaje/json/node/CustomAdapterTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/CustomAdapterTest.java
@@ -1,0 +1,63 @@
+package io.avaje.json.node;
+
+import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CustomAdapterTest {
+
+  static final JsonNodeMapper mapper = JsonNodeMapper.builder().build();
+
+  @Test
+  void mapUsingCustomAdapter() {
+
+    MyAdapter myAdapter = new MyAdapter(mapper);
+
+    NodeMapper<MyCustomType> typeMapper = mapper.mapper(myAdapter);
+
+    MyCustomType source = new MyCustomType();
+    source.foo = "hi";
+    source.bar = 42;
+    String asJson = typeMapper.toJson(source);
+
+    MyCustomType fromJson = typeMapper.fromJson(asJson);
+
+    assertThat(fromJson.foo).isEqualTo(source.foo);
+    assertThat(fromJson.bar).isEqualTo(source.bar);
+  }
+
+  static class MyCustomType {
+    public String foo;
+    public int bar;
+  }
+
+  static class MyAdapter implements JsonAdapter<MyCustomType> {
+
+    final NodeMapper<JsonObject> objectMapper;
+
+    public MyAdapter(JsonNodeMapper mapper) {
+      this.objectMapper = mapper.objectMapper();
+    }
+
+    @Override
+    public void toJson(JsonWriter writer, MyCustomType value) {
+      var jsonObject = JsonObject.create()
+        .add("foo", value.foo)
+        .add("bar", value.bar);
+      objectMapper.toJson(jsonObject, writer);
+    }
+
+    @Override
+    public MyCustomType fromJson(JsonReader reader) {
+      JsonObject jsonObject = objectMapper.fromJson(reader);
+
+      MyCustomType myCustomType = new MyCustomType();
+      myCustomType.foo = jsonObject.extract("foo");
+      myCustomType.bar = jsonObject.extract("bar", 0);
+      return myCustomType;
+    }
+  }
+}


### PR DESCRIPTION
For cases where we want to manually build a JsonAdapter and then use that via JsonNodeMapper.

For example, manually build JsonAdapter using JsonObject.extract() methods to extract out values and deal with number types etc.