### PR TITLE
[json-core] Rename the Maven ArtifactId to avaje-json-core

### DIFF
--- a/json-core/pom.xml
+++ b/json-core/pom.xml
@@ -9,7 +9,7 @@
     <version>3.0-RC2</version>
   </parent>
 
-  <artifactId>avaje-json</artifactId>
+  <artifactId>avaje-json-core</artifactId>
 
   <dependencies>
     <dependency>

--- a/json-node/pom.xml
+++ b/json-node/pom.xml
@@ -25,8 +25,8 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-json</artifactId>
-      <version>3.0-RC1</version>
+      <artifactId>avaje-json-core</artifactId>
+      <version>3.0-RC2</version>
     </dependency>
 
     <dependency>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -15,7 +15,7 @@
 
     <dependency>
       <groupId>io.avaje</groupId>
-      <artifactId>avaje-json</artifactId>
+      <artifactId>avaje-json-core</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
I think avaje-json is too close to avaje-jsonb (like typo close) and so I think it would be better for core to be avaje-json-core.