### PR TITLE
[json-core] Add SimpleMapper.properties() method, option to use PropertyNames optimisation

### DIFF
--- a/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
@@ -1,6 +1,7 @@
 package io.avaje.json.simple;
 
 import io.avaje.json.JsonAdapter;
+import io.avaje.json.PropertyNames;
 import io.avaje.json.core.CoreTypes;
 import io.avaje.json.stream.JsonStream;
 
@@ -19,6 +20,11 @@ final class DSimpleMapper implements SimpleMapper {
     this.objectType = new DTypeMapper<>(adapters.objectAdapter(), jsonStream);
     this.mapType = new DTypeMapper<>(adapters.mapAdapter(), jsonStream);
     this.listType = new DTypeMapper<>(adapters.listAdapter(), jsonStream);
+  }
+
+  @Override
+  public PropertyNames properties(String... names) {
+    return jsonStream.properties(names);
   }
 
   @Override

--- a/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
@@ -3,6 +3,7 @@ package io.avaje.json.simple;
 import io.avaje.json.JsonAdapter;
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.avaje.json.PropertyNames;
 import io.avaje.json.stream.JsonStream;
 
 import java.io.InputStream;
@@ -41,6 +42,14 @@ public interface SimpleMapper {
   static Builder builder() {
     return new DSimpleMapperBuilder();
   }
+
+  /**
+   * Return the property names as PropertyNames.
+   * <p>
+   * Provides the option of optimising the writing of json for property names
+   * by having them already escaped and encoded rather than as plain strings.
+   */
+  PropertyNames properties(String... names);
 
   /**
    * Return a mapper for Object with more reading/writing options.

--- a/json-core/src/test/java/io/avaje/json/simple/CustomAdapter2Test.java
+++ b/json-core/src/test/java/io/avaje/json/simple/CustomAdapter2Test.java
@@ -3,6 +3,7 @@ package io.avaje.json.simple;
 import io.avaje.json.JsonAdapter;
 import io.avaje.json.JsonReader;
 import io.avaje.json.JsonWriter;
+import io.avaje.json.PropertyNames;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,7 +15,8 @@ class CustomAdapter2Test {
   @Test
   void mapUsingCustomAdapter() {
 
-    MyAdapterUsingRaw myAdapter = new MyAdapterUsingRaw();
+    PropertyNames names = simpleMapper.properties("foo", "bar");
+    MyAdapterUsingRaw myAdapter = new MyAdapterUsingRaw(names);
 
     SimpleMapper.Type<MyOtherType> type = simpleMapper.type(myAdapter);
 
@@ -36,12 +38,21 @@ class CustomAdapter2Test {
 
   static class MyAdapterUsingRaw implements JsonAdapter<MyOtherType> {
 
+      private final PropertyNames names;
+
+      MyAdapterUsingRaw(PropertyNames names) {
+          this.names = names;
+      }
+
     @Override
     public void toJson(JsonWriter writer, MyOtherType value) {
-      writer.beginObject();
-      writer.name("foo");
+      writer.beginObject(names);
+      writer.name(0);
+      // writer.beginObject();
+      // writer.name("foo");
       writer.value(value.foo);
-      writer.name("bar");
+      writer.name(1);
+      //writer.name("bar");
       writer.value(value.bar);
       writer.endObject();
     }


### PR DESCRIPTION
Make this performance optimisation available via SimpleMapper. The PropertyNames are pre-encoded, and can give a performance boost in both writing and reading.