### PR TITLE
[json-core] Add helper toJson() fromJson() methods that use JsonReader JsonWriter

### DIFF
--- a/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/DSimpleMapper.java
@@ -1,6 +1,8 @@
 package io.avaje.json.simple;
 
 import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
 import io.avaje.json.PropertyNames;
 import io.avaje.json.core.CoreTypes;
 import io.avaje.json.stream.JsonStream;
@@ -53,8 +55,23 @@ final class DSimpleMapper implements SimpleMapper {
   }
 
   @Override
+  public void toJson(Object object, JsonWriter jsonWriter) {
+    objectType.toJson(object, jsonWriter);
+  }
+
+  @Override
   public Object fromJson(String json) {
     return objectType.fromJson(json);
+  }
+
+  @Override
+  public Object fromJson(JsonReader jsonReader) {
+    return objectType.fromJson(jsonReader);
+  }
+
+  @Override
+  public Map<String, Object> fromJsonObject(JsonReader jsonReader) {
+    return mapType.fromJson(jsonReader);
   }
 
   @Override
@@ -65,5 +82,10 @@ final class DSimpleMapper implements SimpleMapper {
   @Override
   public List<Object> fromJsonArray(String json) {
     return listType.fromJson(json);
+  }
+
+  @Override
+  public List<Object> fromJsonArray(JsonReader jsonReader) {
+    return listType.fromJson(jsonReader);
   }
 }

--- a/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
+++ b/json-core/src/main/java/io/avaje/json/simple/SimpleMapper.java
@@ -74,9 +74,22 @@ public interface SimpleMapper {
   String toJson(Object object);
 
   /**
+   * Write the object to JsonWriter.
+   * <p>
+   * For options to write json content to OutputStream, Writer etc
+   * use {@link Type}.
+   */
+  void toJson(Object object, JsonWriter jsonWriter);
+
+  /**
    * Read the object from JSON string.
    */
   Object fromJson(String json);
+
+  /**
+   * Read the object from JSON.
+   */
+  Object fromJson(JsonReader jsonReader);
 
   /**
    * Read a Map from JSON OBJECT string.
@@ -86,11 +99,25 @@ public interface SimpleMapper {
   Map<String, Object> fromJsonObject(String json);
 
   /**
+   * Read a Map from JSON OBJECT.
+   * <p>
+   * Use {@link #map()} for more reading options.
+   */
+  Map<String, Object> fromJsonObject(JsonReader jsonReader);
+
+  /**
    * Read a List from JSON ARRAY string.
    * <p>
    * Use {@link #list()} for more reading options.
    */
   List<Object> fromJsonArray(String json);
+
+  /**
+   * Read a List from JSON ARRAY.
+   * <p>
+   * Use {@link #list()} for more reading options.
+   */
+  List<Object> fromJsonArray(JsonReader jsonReader);
 
   /**
    * Return the property names as PropertyNames.

--- a/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonNodeMapper.java
@@ -1,6 +1,8 @@
 package io.avaje.json.node;
 
 import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
 import io.avaje.json.PropertyNames;
 import io.avaje.json.node.adapter.NodeAdapterBuilder;
 import io.avaje.json.simple.SimpleMapper;
@@ -88,6 +90,17 @@ public interface JsonNodeMapper {
   String toJson(JsonNode node);
 
   /**
+   * Write the node to JSON.
+   * <p>
+   * For options to write json content to OutputStream, Writer etc
+   * use {@link #nodeMapper()}.
+   *
+   * @see SimpleMapper.Type#toJson(Object, OutputStream)
+   * @see SimpleMapper.Type#toJson(Object, Writer)
+   */
+  void toJson(JsonNode node, JsonWriter jsonWriter);
+
+  /**
    * Read any json content returning a JsonNode.
    * <p>
    * For options to read json content from InputStream, Reader etc
@@ -105,6 +118,17 @@ public interface JsonNodeMapper {
   JsonNode fromJson(String json);
 
   /**
+   * Read any json content returning a JsonNode.
+   * <p>
+   * For options to read json content from InputStream, Reader etc
+   * use the fromJson methods on {@link SimpleMapper.Type}.
+   *
+   * @see SimpleMapper.Type#fromJson(Reader)
+   * @see SimpleMapper.Type#fromJson(InputStream)
+   */
+  JsonNode fromJson(JsonReader jsonReader);
+
+  /**
    * Read a JsonObject from json string content.
    * <p>
    * Use this when we know that the json content is a JsonObject.
@@ -115,6 +139,13 @@ public interface JsonNodeMapper {
   JsonObject fromJsonObject(String json);
 
   /**
+   * Read a JsonObject from json string content.
+   * <p>
+   * Use this when we know that the json content is a JsonObject.
+   */
+  JsonObject fromJsonObject(JsonReader jsonReader);
+
+  /**
    * Read a JsonArray from json string content.
    * <p>
    * Use this when we know that the json content is a JsonArray.
@@ -123,6 +154,13 @@ public interface JsonNodeMapper {
    * @return The JsonArray parsed from the content.
    */
   JsonArray fromJsonArray(String json);
+
+  /**
+   * Read a JsonArray from json string content.
+   * <p>
+   * Use this when we know that the json content is a JsonArray.
+   */
+  JsonArray fromJsonArray(JsonReader jsonReader);
 
   /**
    * Helper method to read JSON with an expected JsonNode type.

--- a/json-node/src/main/java/io/avaje/json/node/adapter/DJsonNodeMapper.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/DJsonNodeMapper.java
@@ -2,6 +2,7 @@ package io.avaje.json.node.adapter;
 
 import io.avaje.json.JsonAdapter;
 import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
 import io.avaje.json.PropertyNames;
 import io.avaje.json.node.*;
 import io.avaje.json.simple.SimpleMapper;
@@ -64,6 +65,11 @@ final class DJsonNodeMapper implements JsonNodeMapper {
   }
 
   @Override
+  public void toJson(JsonNode node, JsonWriter jsonWriter) {
+    nodeAdapter.toJson(jsonWriter, node);
+  }
+
+  @Override
   public JsonNode fromJson(String json) {
     try (JsonReader reader = jsonStream.reader(json)) {
       return nodeAdapter.fromJson(reader);
@@ -82,6 +88,21 @@ final class DJsonNodeMapper implements JsonNodeMapper {
     try (JsonReader reader = jsonStream.reader(json)) {
       return arrayAdapter.fromJson(reader);
     }
+  }
+
+  @Override
+  public JsonNode fromJson(JsonReader jsonReader) {
+    return nodeAdapter.fromJson(jsonReader);
+  }
+
+  @Override
+  public JsonObject fromJsonObject(JsonReader jsonReader) {
+    return objectAdapter.fromJson(jsonReader);
+  }
+
+  @Override
+  public JsonArray fromJsonArray(JsonReader jsonReader) {
+    return arrayAdapter.fromJson(jsonReader);
   }
 
   @Override

--- a/json-node/src/test/java/io/avaje/json/node/adapter/JsonNodeAdaptersTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/adapter/JsonNodeAdaptersTest.java
@@ -4,6 +4,7 @@ import io.avaje.json.JsonAdapter;
 import io.avaje.json.JsonReader;
 import io.avaje.json.node.*;
 import io.avaje.json.simple.SimpleMapper;
+import io.avaje.json.stream.BufferedJsonWriter;
 import io.avaje.json.stream.JsonStream;
 import org.junit.jupiter.api.Test;
 
@@ -102,6 +103,36 @@ class JsonNodeAdaptersTest {
     assertThat(jsonAdapter).isSameAs(adapter);
   }
 
+  @Test
+  void toJsonWriter() {
+    BufferedJsonWriter writer = stream.bufferedWriter();
+    mapper.toJson(JsonArray.create().add(1).add(2), writer);
+    assertThat(writer.result()).isEqualTo("[1,2]");
+  }
+
+  @Test
+  void fromJson_usingReader() {
+    try (var reader = stream.reader("[42, \"foo\"]")) {
+      JsonNode node = mapper.fromJson(reader);
+      assertThat(node).isEqualTo(JsonArray.create().add(42L).add("foo"));
+    }
+  }
+
+  @Test
+  void fromJsonArray_usingReader() {
+    try (var reader = stream.reader("[42, \"foo\"]")) {
+      JsonArray node = mapper.fromJsonArray(reader);
+      assertThat(node).isEqualTo(JsonArray.create().add(42L).add("foo"));
+    }
+  }
+
+  @Test
+  void fromJsonObject_usingReader() {
+    try (var reader = stream.reader("{\"a\":1,\"b\":2}")) {
+      JsonObject node = mapper.fromJsonObject(reader);
+      assertThat(node).isEqualTo(JsonObject.create().add("a", 1L).add("b", 2L));
+    }
+  }
 
   @Test
   void arrayCreateOfMixed_defaultStream() {


### PR DESCRIPTION
This makes it more trivially obvious when using SimpleMapper or JsonNodeMapper to implement a JsonAdapter [where the API uses JsonReader and JsonWriter]