### PR TITLE
Add Jsonb.toJson() using JsonOutput

### DIFF
--- a/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
@@ -1,6 +1,7 @@
 package org.example.customer;
 
 import io.avaje.json.*;
+import io.avaje.json.stream.JsonOutput;
 import io.avaje.jsonb.*;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +51,17 @@ class CustomerTest {
     var customer = new Customer().id(42L).name("rob").status(Customer.Status.ACTIVE);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     jsonb.toJson(customer,  baos);
+    String asString = baos.toString(StandardCharsets.UTF_8);
+    assertThat(asString).isEqualTo("{\"id\":42,\"name\":\"rob\",\"status\":\"ACTIVE\"}");
+  }
+
+  @Test
+  void anyToJsonOutput() {
+    var customer = new Customer().id(42L).name("rob").status(Customer.Status.ACTIVE);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    JsonOutput jsonOutput = JsonOutput.ofStream(baos);
+
+    jsonb.toJson(customer,  jsonOutput);
     String asString = baos.toString(StandardCharsets.UTF_8);
     assertThat(asString).isEqualTo("{\"id\":42,\"name\":\"rob\",\"status\":\"ACTIVE\"}");
   }

--- a/json-core/src/main/java/io/avaje/json/stream/JsonOutput.java
+++ b/json-core/src/main/java/io/avaje/json/stream/JsonOutput.java
@@ -9,6 +9,12 @@ import java.io.OutputStream;
 /**
  * Output that can be aware of server content chunking.
  * <p>
+ * We can use an implementation of JsonOutput such that it can make use of
+ * the underlying buffer used by avaje-jsonb, using {@link #writeLast(byte[], int, int)}
+ * to know if the content is complete (and typically can be written directly as fixed
+ * content) or if the content is still being written (and potentially written by an
+ * http server as chunked content).
+ * <p>
  * Typically, for HTTP servers that can send output using fixed length or chunked.
  */
 public interface JsonOutput extends Closeable {
@@ -16,6 +22,14 @@ public interface JsonOutput extends Closeable {
   /**
    * Create as a simple wrapper for OutputStream.
    */
+  static JsonOutput ofStream(OutputStream outputStream) {
+    return new DJsonOutput(outputStream);
+  }
+
+  /**
+   * @deprecated migrate to {@link #ofStream(OutputStream)}.
+   */
+  @Deprecated
   static JsonOutput of(OutputStream outputStream) {
     return new DJsonOutput(outputStream);
   }

--- a/json-core/src/main/java/io/avaje/json/stream/core/CoreJsonStream.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/CoreJsonStream.java
@@ -88,7 +88,7 @@ final class CoreJsonStream implements JsonStream {
 
   @Override
   public JsonWriter writer(OutputStream outputStream) {
-    return writer(JsonOutput.of(outputStream));
+    return writer(JsonOutput.ofStream(outputStream));
   }
 
   @Override

--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -154,6 +154,13 @@ public interface Jsonb {
   void toJson(Object any, JsonWriter jsonWriter);
 
   /**
+   * Write to the given jsonOutput.
+   * <p>
+   * This is a convenience method for {@code jsonb.type(Object.class).toJson(any, jsonOutput) }
+   */
+  void toJson(Object any, JsonOutput jsonOutput);
+
+  /**
    * Return the JsonType used to read and write json for the given class.
    *
    * <h3>fromJson() example</h3>

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -91,6 +91,11 @@ final class DJsonb implements Jsonb {
   }
 
   @Override
+  public void toJson(Object any, JsonOutput jsonOutput) {
+    anyType.toJson(any, jsonOutput);
+  }
+
+  @Override
   public PropertyNames properties(String... names) {
     return io.properties(names);
   }


### PR DESCRIPTION
This method is on JsonType but was missing on Jsonb itself.

Also deprecate JsonOutput.of() taking an OutputStream in favour of JsonOutput.ofStream() in order to skip method overloading on the option helidon server response type.