### PR TITLE
[bug] @Json.Property name not used to match getters/setters/constructors using property name

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/naming/PropertyUnderscore.java
+++ b/blackbox-test/src/main/java/org/example/customer/naming/PropertyUnderscore.java
@@ -1,0 +1,55 @@
+package org.example.customer.naming;
+
+import java.util.Objects;
+
+import io.avaje.jsonb.Json;
+import io.avaje.jsonb.Json.Naming;
+
+@Json(naming = Naming.LowerUnderscore)
+public class PropertyUnderscore {
+
+  @Json.Property("name")
+  private final String _name;
+
+  @Json.Property("email")
+  private final String _email;
+
+  @Json.Property("setter")
+  private String _setter;
+
+  public PropertyUnderscore(String name, String email) {
+    this._name = name;
+    this._email = email;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public String getEmail() {
+    return _email;
+  }
+
+  public String getSetter() {
+    return _setter;
+  }
+
+  public void setSetter(String setter) {
+    this._setter = setter;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_email, _name, _setter);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if ((obj == null) || (getClass() != obj.getClass())) return false;
+    PropertyUnderscore other = (PropertyUnderscore) obj;
+    return Objects.equals(_email, other._email)
+        && Objects.equals(_name, other._name)
+        && Objects.equals(_setter, other._setter);
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/naming/PropertyUnderscoreTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/naming/PropertyUnderscoreTest.java
@@ -1,0 +1,27 @@
+package org.example.customer.naming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+
+class PropertyUnderscoreTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<PropertyUnderscore> jsonType = jsonb.type(PropertyUnderscore.class);
+
+  @Test
+  void upperUnderscore_toFrom() {
+    var bean = new PropertyUnderscore("sim", "simPlus");
+    bean.setSetter("set");
+
+    String asJson = jsonType.toJson(bean);
+    assertThat(asJson).isEqualTo("{\"name\":\"sim\",\"email\":\"simPlus\",\"setter\":\"set\"}");
+
+    var fromJson = jsonType.fromJson(asJson);
+    assertEquals(fromJson, bean);
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -307,12 +307,12 @@ final class TypeReader {
 
     var propName = field.propertyName();
     var fieldName = field.fieldName();
-    return !matchSetter(propName, field, false)
-        && !matchSetter(propName, field, true)
-        && !matchFieldToSetterByParam(propName, field)
-        && !matchSetter(fieldName, field, false)
+    return !matchSetter(fieldName, field, false)
         && !matchSetter(fieldName, field, true)
         && !matchFieldToSetterByParam(fieldName, field)
+        && !matchSetter(propName, field, false)
+        && !matchSetter(propName, field, true)
+        && !matchFieldToSetterByParam(propName, field)
         && !field.isPublicField()
         && !field.isSubTypeField();
   }
@@ -368,10 +368,10 @@ final class TypeReader {
   private void matchFieldToGetter(FieldReader field) {
     var propName = field.propertyName();
     var fieldName = field.fieldName();
-    if (!matchGetter(propName, field, false)
-        && !matchGetter(propName, field, true)
-        && !matchGetter(fieldName, field, false)
+    if (!matchGetter(fieldName, field, false)
         && !matchGetter(fieldName, field, true)
+        && !matchGetter(propName, field, false)
+        && !matchGetter(propName, field, true)
         && !field.isPublicField()
         && !field.isSubTypeField()) {
       nonAccessibleField = true;

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/naming/PropertyUnderscore.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/naming/PropertyUnderscore.java
@@ -1,0 +1,27 @@
+package io.avaje.jsonb.generator.models.valid.naming;
+
+import io.avaje.jsonb.Json;
+import io.avaje.jsonb.Json.Naming;
+
+@Json(naming = Naming.LowerUnderscore)
+public class PropertyUnderscore {
+
+  @Json.Property("name")
+  private final String _name;
+
+  @Json.Property("email")
+  private final String _email;
+
+  public PropertyUnderscore(String name, String email) {
+    this._name = name;
+    this._email = email;
+  }
+
+  public String getName() {
+    return _name;
+  }
+
+  public String getEmail() {
+    return _email;
+  }
+}


### PR DESCRIPTION
Now will read the getter/setter methods using the property name if no match if found for the field name.

This was prompted by
![image](https://github.com/user-attachments/assets/57d8e476-e675-4b62-9450-f6d0d85a88ab)
