### PR TITLE
Add support for JAX-B style collections that don't have setters

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/jaxb/MyJaxbType.java
+++ b/blackbox-test/src/main/java/org/example/customer/jaxb/MyJaxbType.java
@@ -1,0 +1,46 @@
+package org.example.customer.jaxb;
+
+import io.avaje.jsonb.Json;
+
+import java.util.*;
+
+@Json
+public class MyJaxbType {
+
+  private String name;
+
+  private List<String> tags;
+  private Set<String> tags2;
+  private Collection<Long> tags3;
+
+
+  public String name() {
+    return name;
+  }
+
+  public MyJaxbType setName(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public List<String> getTags() {
+    if (tags == null) {
+      tags = new ArrayList<>();
+    }
+    return tags;
+  }
+
+  public Set<String> getTags2() {
+    if (tags2 == null) {
+      tags2 = new LinkedHashSet<>();
+    }
+    return tags2;
+  }
+
+  public Collection<Long> getTags3() {
+    if (tags3 == null) {
+      tags3 = new TreeSet<>();
+    }
+    return tags3;
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/jaxb/MyJaxbTypeTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/jaxb/MyJaxbTypeTest.java
@@ -1,0 +1,52 @@
+package org.example.customer.jaxb;
+
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyJaxbTypeTest {
+  Jsonb jsonb = Jsonb.builder().build();
+
+  @Test
+  void toJsonFromJson() {
+    final var bean = new MyJaxbType();
+    bean.setName("red");
+    bean.getTags().add("a");
+    bean.getTags().add("b");
+    bean.getTags2().add("i");
+    bean.getTags2().add("j");
+    bean.getTags3().add(50L);
+    bean.getTags3().add(51L);
+    bean.getTags3().add(52L);
+
+    final var asJson = jsonb.toJson(bean);
+    assertThat(asJson).isEqualTo("{\"name\":\"red\",\"tags\":[\"a\",\"b\"],\"tags2\":[\"i\",\"j\"],\"tags3\":[50,51,52]}");
+
+    final var fromJson = jsonb.type(MyJaxbType.class).fromJson(asJson);
+    assertThat(fromJson.name()).isEqualTo("red");
+    assertThat(fromJson.getTags()).containsOnly("a", "b");
+    assertThat(fromJson.getTags2()).containsOnly("i", "j");
+    assertThat(fromJson.getTags3()).containsOnly(50L, 51L, 52L);
+  }
+
+  @Test
+  void emptyList() {
+    final var bean = new MyJaxbType();
+    final var asJson = jsonb.toJson(bean);
+    assertThat(asJson).isEqualTo("{\"tags\":[],\"tags2\":[],\"tags3\":[]}");
+
+    final var fromJson = jsonb.type(MyJaxbType.class).fromJson("{}");
+    assertThat(fromJson.name()).isNull();
+    assertThat(fromJson.getTags()).isEmpty();
+    assertThat(fromJson.getTags2()).isEmpty();
+    assertThat(fromJson.getTags3()).isEmpty();
+
+
+    final var fromJson2 = jsonb.type(MyJaxbType.class).fromJson("{\"tags\":[],\"tags2\":[],\"tags3\":[]}");
+    assertThat(fromJson2.name()).isNull();
+    assertThat(fromJson2.getTags()).isEmpty();
+    assertThat(fromJson2.getTags2()).isEmpty();
+    assertThat(fromJson2.getTags3()).isEmpty();
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
@@ -337,12 +337,14 @@ final class FieldProperty {
     }
   }
 
-  public void writeFromJsonSwitch(Append writer, String varName, boolean defaultConstructor) {
+  public void writeFromJsonSwitch(Append writer, String varName, boolean defaultConstructor, boolean useGetterAddAll) {
     if (defaultConstructor) {
       if (setter != null) {
         writer.append("          _$%s.%s(%s.fromJson(reader));", varName, setter.getName(), adapterFieldName);
       } else if (publicField) {
         writer.append("          _$%s.%s = %s.fromJson(reader);", varName, fieldName, adapterFieldName);
+      } else if (useGetterAddAll) {
+        writer.append("          _$%s.%s().addAll(%s.fromJson(reader));", varName, getter.getName(), adapterFieldName);
       }
     } else {
       writer.append("          _val$%s = %s.fromJson(reader);", fieldName, adapterFieldName);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -23,6 +23,7 @@ final class FieldReader {
   private boolean isSubTypeField;
   private final String num;
   private boolean isCreatorParam;
+  private boolean useGetterAddAll;
 
   FieldReader(
       Element element,
@@ -243,7 +244,7 @@ final class FieldReader {
     if (!deserialize) {
       writer.append("          reader.skipValue();");
     } else {
-      property.writeFromJsonSwitch(writer, varName, defaultConstructor);
+      property.writeFromJsonSwitch(writer, varName, defaultConstructor, useGetterAddAll);
     }
     writer.eol().append("          break;").eol().eol();
   }
@@ -300,5 +301,9 @@ final class FieldReader {
 
   Element element() {
     return element;
+  }
+
+  void setUseGetterAddAll() {
+    useGetterAddAll = true;
   }
 }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -299,8 +299,7 @@ final class TypeReader {
 
   private void matchFieldToSetter(FieldReader field) {
     if (hasNoSetter(field)) {
-      GenericType type = field.type();
-      if (isCollectionType(type)) {
+      if (isCollectionType(field.type())) {
         field.setUseGetterAddAll();
       } else {
         logError("Non public field " + baseType + " " + field.fieldName() + " with no matching setter or constructor?");
@@ -309,7 +308,7 @@ final class TypeReader {
   }
 
   private boolean isCollectionType(GenericType genericType) {
-    String topType = genericType.topType();
+    final String topType = genericType.topType();
     return "java.util.List".equals(topType)
       || "java.util.Set".equals(topType)
       || "java.util.Collection".equals(topType);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -299,12 +299,23 @@ final class TypeReader {
 
   private void matchFieldToSetter(FieldReader field) {
     if (hasNoSetter(field)) {
-      logError("Non public field " + baseType + " " + field.fieldName() + " with no matching setter or constructor?");
+      GenericType type = field.type();
+      if (isCollectionType(type)) {
+        field.setUseGetterAddAll();
+      } else {
+        logError("Non public field " + baseType + " " + field.fieldName() + " with no matching setter or constructor?");
+      }
     }
   }
 
-  private boolean hasNoSetter(FieldReader field) {
+  private boolean isCollectionType(GenericType genericType) {
+    String topType = genericType.topType();
+    return "java.util.List".equals(topType)
+      || "java.util.Set".equals(topType)
+      || "java.util.Collection".equals(topType);
+  }
 
+  private boolean hasNoSetter(FieldReader field) {
     var propName = field.propertyName();
     var fieldName = field.fieldName();
     return !matchSetter(fieldName, field, false)


### PR DESCRIPTION
Instead they have getter methods that initialise the collection like:

```java
  public List<String> getTags() {
    if (tags == null) {
      tags = new ArrayList<>();
    }
    return tags;
  }
```

This change detects the case when a field does not have any matching constructor or setter, and it's a collection type (List,Set,Collection), then we assume it follows JAX-B style and the getter will initialise the collection.

We then generate code that uses the getter + addAll() ... instead of failing with the error:

"Non public field org.example.MyJaxbType tags with no matching setter or constructor?"