### PR TITLE
Improve the compiler error with Json.Import / Json.Mixin prefix

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/package-info.java
+++ b/blackbox-test/src/main/java/org/example/customer/package-info.java
@@ -1,4 +1,4 @@
-@Json.Import(MyOtherClass.class)
+@Json.Import({MyOtherClass.class}) //, java.util.Calendar.class})
 package org.example.customer;
 
 import io.avaje.jsonb.Json;

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -43,11 +43,11 @@ final class ClassReader implements BeanReader {
   /** An Interface/abstract type with a single implementation */
   private ClassReader implementation;
 
-  ClassReader(TypeElement beanType) {
-    this(beanType, null);
+  ClassReader(TypeElement beanType, String errorContext) {
+    this(beanType, null, errorContext);
   }
 
-  ClassReader(TypeElement beanType, TypeElement mixInElement) {
+  ClassReader(TypeElement beanType, TypeElement mixInElement, String errorContext) {
     this.beanType = beanType;
     this.type = beanType.getQualifiedName().toString();
     this.shortName = shortName(beanType);
@@ -55,7 +55,7 @@ final class ClassReader implements BeanReader {
     this.namingConvention = ncReader.get();
     this.typeProperty = ncReader.typeProperty();
     this.caseInsensitiveKeys = ncReader.isCaseInsensitiveKeys();
-    this.typeReader = new TypeReader(beanType, mixInElement, namingConvention, typePropertyKey());
+    this.typeReader = new TypeReader(errorContext, beanType, mixInElement, namingConvention, typePropertyKey());
     typeReader.process();
     this.nonAccessibleField = typeReader.nonAccessibleField();
     this.hasSubTypes = typeReader.hasSubTypes();
@@ -94,7 +94,7 @@ final class ClassReader implements BeanReader {
    * For an interface type set the single implementation to use for fromJson().
    */
   void setImplementationType(TypeElement implementationType) {
-    this.implementation = new ClassReader(implementationType);
+    this.implementation = new ClassReader(implementationType, "");
   }
 
   @Override

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -315,11 +315,11 @@ public final class JsonbProcessor extends AbstractProcessor {
     if (valueElements.contains(typeElement.toString())) {
       return;
     }
-    writeAdapter(typeElement, new ClassReader(typeElement));
+    writeAdapter(typeElement, new ClassReader(typeElement, ""));
   }
 
   private void writeAdapterForImportedType(TypeElement importedType, TypeElement implementationType) {
-    final ClassReader beanReader = new ClassReader(importedType);
+    final ClassReader beanReader = new ClassReader(importedType, "@Json.Import of ");
     if (implementationType != null) {
       beanReader.setImplementationType(implementationType);
     }
@@ -327,7 +327,7 @@ public final class JsonbProcessor extends AbstractProcessor {
   }
 
   private void writeAdapterForMixInType(TypeElement typeElement, TypeElement mixin) {
-    final ClassReader beanReader = new ClassReader(typeElement, mixin);
+    final ClassReader beanReader = new ClassReader(typeElement, mixin, "@Json.Mixin of ");
     writeAdapter(typeElement, beanReader);
   }
 

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -36,6 +36,7 @@ final class TypeReader {
   private final List<String> genericTypeParams;
   private final NamingConvention namingConvention;
   private final boolean hasJsonAnnotation;
+  private final String errorContext;
   private MethodReader constructor;
   private boolean defaultPublicConstructor;
   private final Map<String, MethodReader.MethodParam> constructorParamMap = new LinkedHashMap<>();
@@ -56,7 +57,8 @@ final class TypeReader {
 
   private final boolean hasJsonCreator;
 
-  TypeReader(TypeElement baseType, TypeElement mixInType, NamingConvention namingConvention, String typePropertyKey) {
+  TypeReader(String errorContext, TypeElement baseType, TypeElement mixInType, NamingConvention namingConvention, String typePropertyKey) {
+    this.errorContext = errorContext;
     this.baseType = baseType;
     this.genericTypeParams = initTypeParams(baseType);
     Optional<ExecutableElement> jsonCreator = Optional.empty();
@@ -263,7 +265,7 @@ final class TypeReader {
     // for getter/accessor methods only, not setters
     PropertyPrism.getOptionalOn(methodElement).ifPresent(propertyPrism -> {
       if (!methodElement.getParameters().isEmpty()) {
-        logError("Json.Property can only be placed on Getter Methods, but on %s", methodElement);
+        logError(errorContext + baseType + ", @Json.Property can only be placed on Getter Methods, but on %s", methodElement);
         return;
       }
 
@@ -302,7 +304,7 @@ final class TypeReader {
       if (isCollectionType(field.type())) {
         field.setUseGetterAddAll();
       } else {
-        logError("Non public field " + baseType + " " + field.fieldName() + " with no matching setter or constructor?");
+        logError(errorContext + baseType + ", non public field " + field.fieldName() + " with no matching setter or constructor?");
       }
     }
   }
@@ -386,14 +388,9 @@ final class TypeReader {
         && !field.isSubTypeField()) {
       nonAccessibleField = true;
       if (hasJsonAnnotation) {
-        logError(
-            "Non accessible field "
-                + baseType
-                + " "
-                + field.fieldName()
-                + " with no matching getter?");
+        logError(errorContext + baseType + ", non accessible field " + field.fieldName() + " with no matching getter?");
       } else {
-        logNote("Non accessible field " + baseType + " " + field.fieldName());
+        logNote(errorContext + baseType + ", non accessible field " + field.fieldName());
       }
     }
   }


### PR DESCRIPTION
Improve the compiler error to more clearly indicate the source of the error. Add the Json.Import and Json.Mixin prefix if they are the original source of the error.

Instead of:
```
[ERROR] Non public field java.util.Calendar fields with no matching setter or constructor?
```

Produce:
```
[ERROR] @Json.Import of java.util.Calendar, non public field fields with no matching setter or constructor?
```