### PR TITLE
Fix JDT package errors 

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AdapterName.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/AdapterName.java
@@ -9,7 +9,7 @@ final class AdapterName {
   final String fullName;
 
   AdapterName(TypeElement origin) {
-    String originPackage = APContext.elements().getPackageOf(origin).toString();
+    String originPackage = APContext.elements().getPackageOf(origin).getQualifiedName().toString();
     var name = shortName(origin);
     shortName = name.substring(0, name.length() - 1);
     if ("".equals(originPackage)) {


### PR DESCRIPTION
- It turns out using toString on a package element doesn't print the right package name with some compilers
- Records with `@Property` annotations on record components did not generate correctly with JDT