### PR TITLE
Generated code with "direct return" when no setters required

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -130,6 +130,10 @@ final class FieldReader {
     return deserialize;
   }
 
+  boolean includeFromJsonBuild() {
+    return deserialize && !isCreatorParam && !property.isConstructorParam();
+  }
+
   boolean includeToJson() {
     return serialize;
   }


### PR DESCRIPTION
Instead of generating code like:

```java
   MyType myType = new MyType(...);
   return myType;
```

Generate:
```java
   return new MyType(...);
```