### PR TITLE
Fix JAXB collections deserializing null

### DIFF
--- a/blackbox-test/src/test/java/org/example/customer/jaxb/MyJaxbTypeTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/jaxb/MyJaxbTypeTest.java
@@ -49,4 +49,13 @@ class MyJaxbTypeTest {
     assertThat(fromJson2.getTags2()).isEmpty();
     assertThat(fromJson2.getTags3()).isEmpty();
   }
+
+  @Test
+  void nullList() {
+    final var fromJson = jsonb.type(MyJaxbType.class).fromJson("{\"tags\":null,\"tags2\":[],\"name\":\"red\"}");
+    assertThat(fromJson.name()).isEqualTo("red");
+    assertThat(fromJson.getTags()).isEmpty();
+    assertThat(fromJson.getTags2()).isEmpty();
+    assertThat(fromJson.getTags3()).isEmpty();
+  }
 }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
@@ -344,7 +344,7 @@ final class FieldProperty {
       } else if (publicField) {
         writer.append("          _$%s.%s = %s.fromJson(reader);", varName, fieldName, adapterFieldName);
       } else if (useGetterAddAll) {
-        writer.append("          _$%s.%s().addAll(%s.fromJson(reader));", varName, getter.getName(), adapterFieldName);
+        writer.append("          _$%s.%s().addAll(Types.nullToEmpty(%s.fromJson(reader)));", varName, getter.getName(), adapterFieldName);
       }
     } else {
       writer.append("          _val$%s = %s.fromJson(reader);", fieldName, adapterFieldName);

--- a/jsonb/src/main/java/io/avaje/jsonb/Types.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Types.java
@@ -18,19 +18,20 @@ package io.avaje.jsonb;
 import io.avaje.jsonb.core.Util;
 
 import java.lang.reflect.*;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
  * Factory methods for types.
  */
-public class Types {
+public final class Types {
 
   private Types() {
     // hide
+  }
+
+  public static <T> Collection<T> nullToEmpty(Collection<T> source) {
+    return source == null ? Collections.emptyList() : source;
   }
 
   /**
@@ -70,7 +71,7 @@ public class Types {
   public static ParameterizedType mapOf(Type valueElementType) {
     return newParameterizedType(Map.class, String.class, valueElementType);
   }
-  
+
   /**
    * Returns a Type that is an Optional of the given element type.
    */


### PR DESCRIPTION
The JAXB collections don't have setters but instead lazy initialise collections on getter methods, the generated code uses <getter>.addAll() which doesn't support the case when NULL is returned (vs empty collection).

Fix is to add a nullToEmpty() helper method for this case (JAXB style collections).

Fix to generated code adds the `Types.nullToEmpty()` like:

```java
case "tags": 
  _$myJaxbType.getTags().addAll(Types.nullToEmpty(listStringJsonAdapter.fromJson(reader)));
  break;

```