### PR TITLE
Fix NPE when custom JsonAdapter (not nullSafe()) is registered via Supplier

### DIFF
--- a/blackbox-test/src/main/java/org/example/other/custom/serializer/CustomExample2.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/serializer/CustomExample2.java
@@ -1,0 +1,11 @@
+package org.example.other.custom.serializer;
+
+import io.avaje.jsonb.Json;
+
+import java.math.BigDecimal;
+
+@Json
+public record CustomExample2(
+    @Json.Serializer(MoneySerializer2.class)
+    BigDecimal amountOwed,
+    BigDecimal somethingElse) {}

--- a/blackbox-test/src/main/java/org/example/other/custom/serializer/MoneySerializer2.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/serializer/MoneySerializer2.java
@@ -1,19 +1,18 @@
 package org.example.other.custom.serializer;
 
+import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonReader;
+import io.avaje.json.JsonWriter;
+import io.avaje.jsonb.CustomAdapter;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
-import io.avaje.json.JsonAdapter;
-import io.avaje.jsonb.CustomAdapter;
-import io.avaje.json.JsonReader;
-import io.avaje.json.JsonWriter;
-import io.avaje.jsonb.Jsonb;
-
 @CustomAdapter(global = false)
-public class MoneySerializer implements JsonAdapter<BigDecimal> {
+public class MoneySerializer2 implements JsonAdapter<BigDecimal> {
 
-  /** Constructor takes Jsonb, registered via AdapterBuilder */
-  public MoneySerializer(Jsonb jsonb) {}
+  /**  Default constructor -> registered via {@code Supplier<JsonAdapter>} */
+  public MoneySerializer2() { }
 
   @Override
   public BigDecimal fromJson(JsonReader reader) {

--- a/blackbox-test/src/test/java/org/example/other/custom/serializer/SelectiveCustomSerializerSupplierTest.java
+++ b/blackbox-test/src/test/java/org/example/other/custom/serializer/SelectiveCustomSerializerSupplierTest.java
@@ -1,0 +1,43 @@
+package org.example.other.custom.serializer;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Uses MoneySerializer2 which is registered via Supplier */
+class SelectiveCustomSerializerSupplierTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<CustomExample2> jsonType = jsonb.type(CustomExample2.class);
+
+  @Test
+  void toFromJson() {
+    final var bean = new CustomExample2(new BigDecimal("100.95630"), new BigDecimal("100.95630"));
+
+    final String asJson = jsonType.toJson(bean);
+    assertThat(asJson).isEqualTo("{\"amountOwed\":100.95,\"somethingElse\":100.95630}");
+
+    final var fromJson = jsonType.fromJson(asJson);
+    assertThat(fromJson.amountOwed()).isEqualTo(new BigDecimal("100.95"));
+    assertThat(fromJson.somethingElse()).isEqualTo(new BigDecimal("100.95630"));
+    assertThat(fromJson).isNotEqualTo(bean);
+  }
+
+  @Test
+  void toFromJson_with_null() {
+    final var bean = new CustomExample2(null, null);
+
+    final String asJson = jsonType.toJson(bean);
+    assertThat(asJson).isEqualTo("{}");
+
+    final var fromJson = jsonType.fromJson(asJson);
+    assertThat(fromJson.amountOwed()).isNull();
+    assertThat(fromJson.somethingElse()).isNull();
+    assertThat(fromJson).isEqualTo(bean);
+  }
+
+}

--- a/blackbox-test/src/test/java/org/example/other/custom/serializer/SelectiveCustomSerializerTest.java
+++ b/blackbox-test/src/test/java/org/example/other/custom/serializer/SelectiveCustomSerializerTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import io.avaje.jsonb.JsonType;
 import io.avaje.jsonb.Jsonb;
 
-class TestSelectiveSerializer {
+/** Uses MoneySerializer which is registered via AdapterBuilder */
+class SelectiveCustomSerializerTest {
 
   Jsonb jsonb = Jsonb.builder().build();
   JsonType<CustomExample> jsonType = jsonb.type(CustomExample.class);
@@ -26,4 +27,18 @@ class TestSelectiveSerializer {
     assertThat(fromJson.somethingElse()).isEqualTo(new BigDecimal("100.95630"));
     assertThat(fromJson).isNotEqualTo(bean);
   }
+
+  @Test
+  void toFromJson_with_null() {
+    final var bean = new CustomExample(null, null);
+
+    final String asJson = jsonType.toJson(bean);
+    assertThat(asJson).isEqualTo("{}");
+
+    final var fromJson = jsonType.fromJson(asJson);
+    assertThat(fromJson.amountOwed()).isNull();
+    assertThat(fromJson.somethingElse()).isNull();
+    assertThat(fromJson).isEqualTo(bean);
+  }
+
 }

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -346,7 +346,7 @@ final class DJsonb implements Jsonb {
     static <T> AdapterFactory newAdapterFactory(Type type, Supplier<JsonAdapter<T>> jsonAdapter) {
       requireNonNull(type);
       requireNonNull(jsonAdapter);
-      return (targetType, jsonb) -> simpleMatch(type, targetType) ? jsonAdapter.get() : null;
+      return (targetType, jsonb) -> simpleMatch(type, targetType) ? jsonAdapter.get().nullSafe() : null;
     }
 
     static AdapterFactory newAdapterFactory(Type type, AdapterBuilder builder) {


### PR DESCRIPTION
Fix in DJsonb by adding `.nullSafe()` for the `Supplier<JsonAdapter<T>>` case.

Example:
```java
@CustomAdapter(global = false)
public class MoneySerializer2 implements JsonAdapter<BigDecimal> {

  /**  Default constructor -> registered via {@code Supplier<JsonAdapter>} */
  public MoneySerializer2() { }

  @Override
  public BigDecimal fromJson(JsonReader reader) {
    return reader.readDecimal().setScale(2, RoundingMode.DOWN);
  }

  @Override
  public void toJson(JsonWriter writer, BigDecimal value) {
    writer.value(value.setScale(2, RoundingMode.DOWN));
  }
}
```

Due to using the default constructor, this custom JsonAdapter is registered via `Supplier<JsonAdapter<T>>` and that wasn't getting the `.nullSafe()` wrapper.
