### PR TITLE
Support using @Json.Ignore on a type

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/IgnoredClass.java
+++ b/blackbox-test/src/main/java/org/example/customer/IgnoredClass.java
@@ -13,6 +13,7 @@ public class IgnoredClass {
   @Json.Ignore private String middleName;
 
   @Property("last")
+  @Json.Ignore(deserialize = true, serialize = true)
   private String lastName;
 
   public IgnoredClass() {}

--- a/blackbox-test/src/main/java/org/example/customer/IgnoredClass.java
+++ b/blackbox-test/src/main/java/org/example/customer/IgnoredClass.java
@@ -1,4 +1,4 @@
-package io.avaje.jsonb.generator.models.valid.ignore;
+package org.example.customer;
 
 import io.avaje.jsonb.Json;
 import io.avaje.jsonb.Json.Ignore;

--- a/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
@@ -18,7 +18,7 @@ class IgnoreClassTest {
     String asJson = jsonb.toJson(bean);
     assertThat(asJson).isEqualTo("{\"firstName\":\"fn\",\"last\":\"ln\"}");
 
-    IgnoreField fromJson = jsonb.type(IgnoreField.class).fromJson(asJson);
+    var fromJson = jsonb.type(IgnoredClass.class).fromJson(asJson);
     assertThat(fromJson.getFirstName()).isNull();
     assertThat(fromJson.getLastName()).isNull();
     assertThat(fromJson.getMiddleName()).isNull();

--- a/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
@@ -1,0 +1,26 @@
+package org.example.customer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.Jsonb;
+
+class IgnoreClassTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+
+  @Test
+  void toJsonFromJson() {
+    var bean = new IgnoredClass("fn", "mn");
+    bean.setLastName("ln");
+
+    String asJson = jsonb.toJson(bean);
+    assertThat(asJson).isEqualTo("{\"firstName\":\"fn\",\"last\":\"ln\"}");
+
+    IgnoreField fromJson = jsonb.type(IgnoreField.class).fromJson(asJson);
+    assertThat(fromJson.getFirstName()).isEqualTo("fn");
+    assertThat(fromJson.getLastName()).isNull();
+    assertThat(fromJson.getMiddleName()).isNull();
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
@@ -20,7 +20,7 @@ class IgnoreClassTest {
 
     var fromJson = jsonb.type(IgnoredClass.class).fromJson(asJson);
     assertThat(fromJson.getFirstName()).isNull();
-    assertThat(fromJson.getLastName()).isNull();
+    assertThat(fromJson.getLastName()).isNotEmpty();
     assertThat(fromJson.getMiddleName()).isNull();
   }
 }

--- a/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/IgnoreClassTest.java
@@ -19,7 +19,7 @@ class IgnoreClassTest {
     assertThat(asJson).isEqualTo("{\"firstName\":\"fn\",\"last\":\"ln\"}");
 
     IgnoreField fromJson = jsonb.type(IgnoreField.class).fromJson(asJson);
-    assertThat(fromJson.getFirstName()).isEqualTo("fn");
+    assertThat(fromJson.getFirstName()).isNull();
     assertThat(fromJson.getLastName()).isNull();
     assertThat(fromJson.getMiddleName()).isNull();
   }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PropertyIgnoreReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PropertyIgnoreReader.java
@@ -1,12 +1,13 @@
 package io.avaje.jsonb.generator;
 
+import java.lang.invoke.MethodHandles;
+import java.util.function.Predicate;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
-import java.lang.invoke.MethodHandles;
-import java.util.function.Predicate;
 
 final class PropertyIgnoreReader {
 
@@ -29,9 +30,14 @@ final class PropertyIgnoreReader {
     ignoreSerialize = propertyMethodOverride;
 
     final IgnorePrism ignored = IgnorePrism.getInstanceOn(element);
+
+    final IgnorePrism ignoreFromType = IgnorePrism.getInstanceOn(element);
     if (ignored != null) {
       ignoreDeserialize = !ignored.deserialize();
       ignoreSerialize = propertyMethodOverride || !ignored.serialize();
+    } else if (ignoreFromType != null) {
+      ignoreDeserialize = !ignoreFromType.deserialize();
+      ignoreSerialize = propertyMethodOverride || !ignoreFromType.serialize();
     }
   }
 

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PropertyIgnoreReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/PropertyIgnoreReader.java
@@ -31,7 +31,7 @@ final class PropertyIgnoreReader {
 
     final IgnorePrism ignored = IgnorePrism.getInstanceOn(element);
 
-    final IgnorePrism ignoreFromType = IgnorePrism.getInstanceOn(element);
+    final IgnorePrism ignoreFromType = IgnorePrism.getInstanceOn(element.getEnclosingElement());
     if (ignored != null) {
       ignoreDeserialize = !ignored.deserialize();
       ignoreSerialize = propertyMethodOverride || !ignored.serialize();

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/SerializerTest.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/SerializerTest.java
@@ -5,9 +5,10 @@ import java.math.BigDecimal;
 import io.avaje.jsonb.Json;
 
 @Json
+@Json.Ignore
 public class SerializerTest {
 
-  @Json.Serializer(MoneySerializer.class)
+  @Json.Property(value = "")
   BigDecimal amount;
 
   @Json.Serializer(MoneySerializer.class)

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/SerializerTest.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/SerializerTest.java
@@ -5,10 +5,9 @@ import java.math.BigDecimal;
 import io.avaje.jsonb.Json;
 
 @Json
-@Json.Ignore
 public class SerializerTest {
 
-  @Json.Property(value = "")
+  @Json.Serializer(MoneySerializer.class)
   BigDecimal amount;
 
   @Json.Serializer(MoneySerializer.class)

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ignore/IgnoredClass.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/ignore/IgnoredClass.java
@@ -1,0 +1,18 @@
+package io.avaje.jsonb.generator.models.valid.ignore;
+
+import java.math.BigDecimal;
+
+import io.avaje.jsonb.Json;
+import io.avaje.jsonb.Json.Ignore;
+
+@Json
+public class IgnoredClass {
+
+  @Json.Property("a")
+  BigDecimal amount;
+
+  BigDecimal amountReturned;
+
+  @Ignore(deserialize = true)
+  BigDecimal somethingElse;
+}

--- a/jsonb/src/main/java/io/avaje/jsonb/Json.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Json.java
@@ -151,18 +151,14 @@ public @interface Json {
    * We can explicitly use {@code serialize=true} to include the property in
    * serialization but not deserialization.
    */
-  @Target(FIELD)
+  @Target({FIELD, TYPE})
   @Retention(SOURCE)
   @interface Ignore {
 
-    /**
-     * Set this explicitly to true to include in serialization.
-     */
+    /** Include in serialization. */
     boolean serialize() default false;
 
-    /**
-     * Set this explicitly to true to include in deserialization.
-     */
+    /** Include in deserialization. */
     boolean deserialize() default false;
   }
 
@@ -241,7 +237,7 @@ public @interface Json {
   @interface SubType {
 
     /**
-     * The concrete type that extends or implements the base type.
+     * Concrete type that extends or implements the base type.
      */
     Class<?> type();
 


### PR DESCRIPTION
Manually setting the ignore on each field gets old after a while

-----------
Allows putting `@Json.Ignore(serialize=true)` on the type such that all properties are not included in deserialisation (or the opposite via `@Json.Ignore(deserialize=true)`.

