### PR TITLE
Fix ComponentReader to register MetaData.Factory if present

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
@@ -56,14 +56,14 @@ final class ComponentReader {
     for (final AnnotationMirror annotationMirror : moduleType.getAnnotationMirrors()) {
 
       final MetaDataPrism metaData = MetaDataPrism.getInstance(annotationMirror);
-      final JsonFactoryPrism metaDataFactory = JsonFactoryPrism.getInstance(annotationMirror);
-
       if (metaData != null) {
         metaData.value().stream()
           .map(TypeMirror::toString)
           .forEach(meta::add);
+      }
 
-      } else if (metaDataFactory != null) {
+      final JsonFactoryPrism metaDataFactory = JsonFactoryPrism.getInstance(annotationMirror);
+      if (metaDataFactory != null) {
         metaDataFactory.value().stream()
           .map(TypeMirror::toString)
           .forEach(meta::addFactory);


### PR DESCRIPTION
It should not be conditional on MetaData, as most often MetaData will be present and it was incorrectly not adding the factories