### PR TITLE
Fix ComponentReader to support no MetaData (only MetaData.Factory is present)

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentReader.java
@@ -38,13 +38,22 @@ final class ComponentReader {
   }
 
   private static boolean hasPublicComponents(TypeElement moduleType) {
-    var firstAdapter =
+    var firstAdapterIsPublic =
       MetaDataPrism.getInstanceOn(moduleType).value().stream()
         .map(APContext::asTypeElement)
         .findFirst()
-        .orElseThrow();
+        .map( a -> a.getModifiers().contains(Modifier.PUBLIC))
+        .orElse(null);
 
-    return firstAdapter.getModifiers().contains(Modifier.PUBLIC);
+    if (firstAdapterIsPublic != null) {
+      return firstAdapterIsPublic;
+    }
+
+    return JsonFactoryPrism.getInstanceOn(moduleType).value().stream()
+      .map(APContext::asTypeElement)
+      .findFirst()
+      .map( a -> a.getModifiers().contains(Modifier.PUBLIC))
+      .orElse(false);
   }
 
   private static boolean isGeneratedComponent(TypeElement moduleType) {


### PR DESCRIPTION
Handle the case when there isn't a MetaData but only MetaData.Factory