### PR TITLE
Fix JsonType.streamAsLines() for empty Stream

### DIFF
--- a/blackbox-test/src/test/java/org/example/customer/stream/StreamBasicTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/stream/StreamBasicTest.java
@@ -27,7 +27,7 @@ class StreamBasicTest {
     JsonType<Stream<MyBasic>> streamType = type.streamAsLines();
 
     String asJson = streamType.toJson(basics.stream());
-    String expected = "{\"id\":1,\"name\":\"a\"}\n{\"id\":2,\"name\":\"b\"}\n{\"id\":3,\"name\":\"c\"}\n";
+    String expected = "{\"id\":1,\"name\":\"a\"}\n{\"id\":2,\"name\":\"b\"}\n{\"id\":3,\"name\":\"c\"}\n\n";
     assertThat(asJson)
       .describedAs("expect new line delimited json content")
       .isEqualTo(expected);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
@@ -30,6 +30,7 @@ final class StreamAdapter<T> implements DJsonClosable<Stream<T>>, JsonAdapter<St
           elementAdapter.toJson(writer, bean);
           writer.writeNewLine();
         });
+        writer.writeNewLine();
       } else {
         writer.beginArray();
         stream.forEach(bean -> elementAdapter.toJson(writer, bean));


### PR DESCRIPTION
When the stream is empty, we still need to send some response body when used with an http server.

The fix for this is to always append a blank empty line to the content. Client consumers are expected to ignore empty content (filter empty lines).