### PR TITLE
Add a static way to retrieve the default instance

### DIFF
--- a/blackbox-test/src/test/java/org/example/customer/ALBResponseTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/ALBResponseTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ALBResponseTest {
 
-  private final Jsonb jsonb = Jsonb.builder().build();
+  private final Jsonb jsonb = Jsonb.instance();
 
   @Test
   void toJson() {

--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -108,6 +108,16 @@ public interface Jsonb {
   }
 
   /**
+   * Get the default Jsonb instance with all generated adapters configured.
+   *
+   * <p>This is a faster alternative to {@code Jsonb.builder().build()} that will return the same
+   * singleton instance.
+   */
+  static Jsonb instance() {
+    return DefaultBootstrap.defaultInstance();
+  }
+
+  /**
    * Return json content for the given object.
    * <p>
    * This is a convenience method for {@code jsonb.type(Object.class).toJson(any) }

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -258,7 +258,7 @@ final class DJsonb implements Jsonb {
    */
   static final class DBuilder implements Jsonb.Builder {
 
-    private static final Jsonb DEFAULT = Jsonb.builder().build();
+    static final Jsonb DEFAULT = Jsonb.builder().build();
 
     private final List<AdapterFactory> factories = new ArrayList<>();
     private boolean failOnUnknown;

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DefaultBootstrap.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DefaultBootstrap.java
@@ -13,4 +13,8 @@ public final class DefaultBootstrap {
   public static Jsonb.Builder builder() {
     return new DJsonb.DBuilder();
   }
+
+  public static Jsonb defaultInstance() {
+    return DJsonb.DBuilder.DEFAULT;
+  }
 }


### PR DESCRIPTION
More often than not, manually configuring the builder is not done.