### PR TITLE
Support writing large raw String content without expanding the underlying buffer

### DIFF
--- a/json-core/src/test/java/io/avaje/json/stream/core/JsonWriterTest.java
+++ b/json-core/src/test/java/io/avaje/json/stream/core/JsonWriterTest.java
@@ -192,4 +192,29 @@ class JsonWriterTest {
       .describedAs("internal buffer should not grow")
       .isEqualTo(100);
   }
+
+  @Test
+  void largeStringAscii() {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    JGenerator dJsonWriter = new JGenerator(100);
+    dJsonWriter.prepare(JsonOutput.ofStream(os));
+
+    JsonWriteAdapter fw = new JsonWriteAdapter(dJsonWriter, HybridBufferRecycler.shared(), true, true);
+
+    String largeValue = '"' + "_1234567890123456789".repeat(21) + '"';
+
+    fw.beginObject();
+    fw.name("key");
+    fw.rawValue(largeValue);
+    fw.endObject();
+    fw.close();
+
+    String jsonResult = new String(os.toByteArray(), 0, os.toByteArray().length);
+    assertThat(jsonResult).isEqualTo("{\"key\":" + largeValue + "}");
+
+    byte[] effectiveBufferSize = dJsonWriter.ensureCapacity(0);
+    assertThat(effectiveBufferSize.length)
+      .describedAs("internal buffer should not grow")
+      .isEqualTo(100);
+  }
 }


### PR DESCRIPTION
Currently, the underlying buffer will expand when writing raw String content that is larger that the buffer. This change writes that as chunks instead.