### PR TITLE
Support writing large raw json content in multiple chunks

### DIFF
--- a/json-core/src/main/java/io/avaje/json/JsonWriter.java
+++ b/json-core/src/main/java/io/avaje/json/JsonWriter.java
@@ -206,8 +206,67 @@ public interface JsonWriter extends Closeable, Flushable {
 
   /**
    * Write raw JSON content.
+   * <p>
+   * If the raw JSON content is really large, we can instead write it in chunks by instead
+   * using {@link #rawChunkStart()} and {@link #rawChunk(String)} etc.
+   *
+   * @see #rawChunkStart()
    */
   void rawValue(String value);
+
+  /**
+   * Start writing a value as multiple raw chunks of JSON content.
+   * <p>
+   * This is for the case of writing a relatively large amount of raw JSON content
+   * in multiple chunks. For smaller content we can just use {@link #rawValue(String)}
+   * instead.
+   *
+   * <pre>{@code
+   *
+   *  // write valid json value as multiple chunks
+   *  writer.rawChunkStart();
+   *  writer.rawChunk('"');
+   *
+   *  // a chunk that doesn't need any encoding
+   *  writer.rawChunk("ab-1234");
+   *
+   *  // a chunk that needs encoding (e.g. contains newline char etc)
+   *  writer.rawChunkEncode("more\n content");
+   *  ...
+   *  writer.rawChunk('"');
+   *  writer.rawChunkEnd();
+   *
+   * }</pre>
+   */
+  void rawChunkStart();
+
+  /**
+   * Write a character as a chunk of raw JSON content.
+   *
+   * @see #rawChunkStart()
+   */
+  void rawChunk(char value);
+
+  /**
+   * Write a chunk of raw JSON content with the value not needing any encoding.
+   *
+   * @see #rawChunkStart()
+   */
+  void rawChunk(String value);
+
+  /**
+   * Write a chunk of raw JSON content encoding as necessary.
+   *
+   * @see #rawChunkStart()
+   */
+  void rawChunkEncode(String value);
+
+  /**
+   * End writing raw chunks of json content.
+   *
+   * @see #rawChunkStart()
+   */
+  void rawChunkEnd();
 
   /**
    * Write new line characters typically for {@code x-json-stream} content.

--- a/json-core/src/main/java/io/avaje/json/stream/DelegateJsonWriter.java
+++ b/json-core/src/main/java/io/avaje/json/stream/DelegateJsonWriter.java
@@ -168,6 +168,31 @@ public abstract class DelegateJsonWriter implements JsonWriter {
   }
 
   @Override
+  public void rawChunkStart() {
+    delegate.rawChunkStart();
+  }
+
+  @Override
+  public void rawChunk(char value) {
+    delegate.rawChunk(value);
+  }
+
+  @Override
+  public void rawChunk(String value) {
+    delegate.rawChunk(value);
+  }
+
+  @Override
+  public void rawChunkEncode(String value) {
+    delegate.rawChunkEncode(value);
+  }
+
+  @Override
+  public void rawChunkEnd() {
+    delegate.rawChunkEnd();
+  }
+
+  @Override
   public final void jsonValue(Object value) {
     delegate.jsonValue(value);
   }

--- a/json-core/src/main/java/io/avaje/json/stream/core/JGenerator.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JGenerator.java
@@ -163,9 +163,14 @@ class JGenerator implements JsonGenerator {
     position = cur;
   }
 
-  /** Break a large string into segments and flush when necessary */
   private void writeLargeString(String text) {
     writeByte(QUOTE);
+    writeStringSegments(text);
+    writeByte(QUOTE);
+  }
+
+  /** Break a large string into segments and flush when necessary */
+  private void writeStringSegments(String text) {
     int left = text.length();
     int offset = 0;
     while (left > 0) {
@@ -177,7 +182,6 @@ class JGenerator implements JsonGenerator {
       offset += len;
       left -= len;
     }
-    writeByte(QUOTE);
   }
 
   private void writeStringEscape(final String str, int i, int cur, final int len) {
@@ -648,6 +652,26 @@ class JGenerator implements JsonGenerator {
   public void writeRaw(String value) {
     prefixValue();
     writeAscii(value);
+  }
+
+  @Override
+  public void startRawChunk() {
+    prefixValue();
+  }
+
+  @Override
+  public void writeRawChunk(String value) {
+    writeAscii(value);
+  }
+
+  @Override
+  public void writeRawChunkEncode(String value) {
+    writeStringSegments(value);
+  }
+
+  @Override
+  public void writeRawChunk(char value) {
+    writeByte((byte) value);
   }
 
   @Override

--- a/json-core/src/main/java/io/avaje/json/stream/core/JsonGenerator.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JsonGenerator.java
@@ -113,6 +113,26 @@ interface JsonGenerator extends Closeable, Flushable {
   void writeRaw(String value);
 
   /**
+   * Start writing raw chunks.
+   */
+  void startRawChunk();
+
+  /**
+   * Write a raw chunk single character.
+   */
+  void writeRawChunk(char value);
+
+  /**
+   * Write a raw chunk that does not need encoding.
+   */
+  void writeRawChunk(String value);
+
+  /**
+   * Write a raw chunk encoding as needed.
+   */
+  void writeRawChunkEncode(String value);
+
+  /**
    * Write a new line. This is typically used when support line delimited x-json-stream content.
    */
   void writeNewLine();

--- a/json-core/src/main/java/io/avaje/json/stream/core/JsonWriteAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JsonWriteAdapter.java
@@ -270,6 +270,32 @@ final class JsonWriteAdapter implements JsonWriter {
   }
 
   @Override
+  public void rawChunkStart() {
+    writeDeferredName();
+    generator.startRawChunk();
+  }
+
+  @Override
+  public void rawChunk(char value) {
+    generator.writeRawChunk(value);
+  }
+
+  @Override
+  public void rawChunk(String value) {
+    generator.writeRawChunk(value);
+  }
+
+  @Override
+  public void rawChunkEncode(String value) {
+    generator.writeRawChunkEncode(value);
+  }
+
+  @Override
+  public void rawChunkEnd() {
+    // do nothing
+  }
+
+  @Override
   public void writeNewLine() {
     generator.writeNewLine();
   }

--- a/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
+++ b/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
@@ -380,6 +380,31 @@ final class JacksonWriter implements JsonWriter {
   }
 
   @Override
+  public void rawChunkStart() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void rawChunk(char value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void rawChunk(String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void rawChunkEncode(String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void rawChunkEnd() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void writeNewLine() {
     try {
       generator.writeRaw('\n');


### PR DESCRIPTION
I've hit an interesting use case where a single json value is a really large amount of content. Instead of writing this content as a really big string, support writing it as multiple small raw chunks.

Note that this feature isn't supported using the Jackson core JsonGenerator.