### PR TITLE
For collection types List, Set, Map use equals() rather than isAssign…

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/GenericType.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/GenericType.java
@@ -167,22 +167,22 @@ final class GenericType {
     if (adapterType != null) {
       return adapterType;
     }
-    return Util.shortName(topType)+".class";
+    return Util.shortName(topType) + ".class";
   }
 
   private String asTypeContainer() {
     GenericType param = params.get(0);
     String containerType = topType();
-    if (isAssignable(containerType, "java.util.List")) {
+    if ("java.util.List".equals(containerType)) {
       return "Types.listOf(" + Util.shortName(param.topType()) + ".class)";
     }
-    if (isAssignable(containerType, "java.util.Set")) {
+    if ("java.util.Set".equals(containerType)) {
       return "Types.setOf(" + Util.shortName(param.topType()) + ".class)";
     }
-    if (isAssignable(containerType, "java.util.stream.Stream")) {
+    if ("java.util.stream.Stream".equals(containerType)) {
       return "Types.streamOf(" + Util.shortName(param.topType()) + ".class)";
     }
-    if (isAssignable(containerType, "java.util.Optional")) {
+    if ("java.util.Optional".equals(containerType)) {
       return "Types.optionalOf(" + Util.shortName(param.topType()) + ".class)";
     }
     return null;


### PR DESCRIPTION
…able() - To support Guava ImmutableList etc

When using isAssignable(), the specialised collection types like Guava ImmutableList get treated like java.util.List and this means that we don't end up using any Custom JsonAdapter that we define for those special types.

Changing to use equals() means that we really expect the java.util List|Set|Map collection types to be used and no ArrayList, LinkedList etc (which would have kind of worked before but not really in that they all would have ended up as ArrayList, LinkedHashSet, LinkedHashMap. So using equals() here should be ok.