### PR TITLE
Fix trailing comma in properties call for empty subtypes

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/EmptySupertype.java
+++ b/blackbox-test/src/main/java/org/example/customer/EmptySupertype.java
@@ -1,0 +1,11 @@
+package org.example.customer;
+
+import io.avaje.jsonb.Json;
+
+@Json
+@Json.SubType(type = EmptySupertype.SubtypeA.class, name = "a")
+@Json.SubType(type = EmptySupertype.SubtypeB.class, name = "b")
+public sealed interface EmptySupertype {
+  record SubtypeA() implements EmptySupertype {}
+  record SubtypeB() implements EmptySupertype {}
+}

--- a/blackbox-test/src/test/java/org/example/customer/EmptySupertypeTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/EmptySupertypeTest.java
@@ -1,0 +1,62 @@
+package org.example.customer;
+
+import io.avaje.json.JsonAdapter;
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EmptySupertypeTest {
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonAdapter<EmptySupertype> adapter = jsonb.adapter(EmptySupertype.class);
+  JsonType<EmptySupertype> type = jsonb.type(EmptySupertype.class);
+
+  @Test
+  void nullObject() {
+    var object = (EmptySupertype) null;
+    var expected = "";
+    var actual = type.toJson(object);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void objectA() {
+    var object = new EmptySupertype.SubtypeA();
+    var expected = "{\"@type\":\"a\"}";
+    var actual = type.toJson(object);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void jsonA() {
+    var json = "{\"@type\":\"a\"}";
+    var expected = new EmptySupertype.SubtypeA();
+    var actual = type.fromJson(json);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void objectB() {
+    var object = new EmptySupertype.SubtypeB();
+    var expected = "{\"@type\":\"b\"}";
+    var actual = type.toJson(object);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void jsonB() {
+    var json = "{\"@type\":\"b\"}";
+    var expected = new EmptySupertype.SubtypeB();
+    var actual = type.fromJson(json);
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void invalidJsonC() {
+    var json = "{\"@type\":\"c\"}";
+    var expected = new EmptySupertype.SubtypeB();
+    assertThrows(IllegalStateException.class, () -> type.fromJson(json));
+  }
+}


### PR DESCRIPTION
Fixes code generation bug where adapters for sealed interfaces with empty subtypes generated invalid Java syntax: jsonb.properties("@type", )

- Refactor property name handling to use LinkedHashSet to avoid duplicates
- Convert to stream-based approach for cleaner code
- Add test case for empty sealed interface subtypes

Fixes #410