### PR TITLE
Add explicit license information to packages' POM file

### DIFF
--- a/json-core/pom.xml
+++ b/json-core/pom.xml
@@ -13,6 +13,14 @@
   <name>avaje json core</name>
   <description>Core JSON Streaming and Generation API</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>io.helidon.webserver</groupId>

--- a/json-node/pom.xml
+++ b/json-node/pom.xml
@@ -13,6 +13,14 @@
   <name>avaje json node</name>
   <description>JSON Node API for avaje-json</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
 
     <dependency>

--- a/jsonb-generator/pom.xml
+++ b/jsonb-generator/pom.xml
@@ -14,6 +14,14 @@
     <avaje.prisms.version>1.43</avaje.prisms.version>
   </properties>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
 
     <dependency>

--- a/jsonb-inject-plugin/pom.xml
+++ b/jsonb-inject-plugin/pom.xml
@@ -13,6 +13,14 @@
   <name>avaje jsonb inject plugin</name>
   <description>avaje-inject plugin for avaje-jsonb</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
 
     <dependency>

--- a/jsonb-jackson/pom.xml
+++ b/jsonb-jackson/pom.xml
@@ -11,6 +11,14 @@
   <name>avaje jsonb jackson</name>
   <description>jackson adapter for avaje-jsonb</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
 
     <dependency>

--- a/jsonb-spring-adapter/pom.xml
+++ b/jsonb-spring-adapter/pom.xml
@@ -13,6 +13,14 @@
   <name>avaje jsonb spring adapter</name>
   <description>springframework adapter for avaje-jsonb</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -11,6 +11,14 @@
   <name>avaje jsonb</name>
   <description>JSON Streaming Generation and data binding library using source code generation</description>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
Having the license information in the POM file allows it to be self-contained. A glance to it is enough to determine licensing.

This is especially important for private artifact mirrors, that often do not allow closed-source, source-available or hard-copyleft libraries to be used. Without the license information on the POM file, some of these repositories will deny mirroring this library.

I'm trying to mirror the Avaje libraries in a private artifact repository, but am running into the issue of the repository not being able to extract the license from the repository (likely not a part of the JARs), which then means that it doesn't mirror the libraries correctly.
