### PR TITLE
Add a hasAdapter method to the JsonB interface

### DIFF
--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -235,6 +235,8 @@ public interface Jsonb {
    * When using <code>Object.class</code> and reading <code>fromJson()</code> then the java types used in
    * the result are determined dynamically based on the json types being read and the resulting java types
    * are ArrayList, LinkedHashMap, String, boolean, and double.
+   *
+   * @throws IllegalStateException if an adapter cannot be found
    */
   <T> JsonType<T> type(Class<T> cls);
 
@@ -279,6 +281,8 @@ public interface Jsonb {
    * When using <code>Object.class</code> and reading <code>fromJson()</code> then the java types used in
    * the result are determined dynamically based on the json types being read and the resulting java types
    * are ArrayList, LinkedHashMap, String, boolean, and double.
+   *
+   * @throws IllegalStateException if an adapter cannot be found
    */
   <T> JsonType<T> type(Type type);
 
@@ -341,6 +345,8 @@ public interface Jsonb {
    *
    * <p>JsonAdapter is generally used by generated serialization code. Application code should use
    * {@link Jsonb#type(Class)} and {@link JsonType} instead.
+   *
+   * @throws IllegalStateException if an adapter cannot be found
    */
   <T> JsonAdapter<T> adapter(Class<T> cls);
 
@@ -349,6 +355,8 @@ public interface Jsonb {
    *
    * <p>JsonAdapter is generally used by generated serialization code. Application code should use
    * {@link Jsonb#type(Type)} and {@link JsonType} instead.
+   *
+   * @throws IllegalStateException if an adapter cannot be found
    */
   <T> JsonAdapter<T> adapter(Type type);
 
@@ -369,20 +377,20 @@ public interface Jsonb {
   JsonAdapter<String> rawAdapter();
 
   /**
-   * Check if a JsonAdapter exists for the given class without attempting to create one.
-   * 
+   * Check if a JsonAdapter exists for the given class.
+   *
    * @param cls The class to check for adapter availability
-   * @return true if an adapter exists or can be created, false otherwise
+   * @return true if an adapter exists, false otherwise
    */
-  <T> boolean hasAdapter(Class<T> cls);
+  boolean hasAdapter(Class<?> cls);
 
   /**
-   * Check if a JsonAdapter exists for the given type without attempting to create one.
-   * 
-   * @param type The type to check for adapter availability  
-   * @return true if an adapter exists or can be created, false otherwise
+   * Check if a JsonAdapter exists for the given type.
+   *
+   * @param type The type to check for adapter availability
+   * @return true if an adapter exists, false otherwise
    */
-  <T> boolean hasAdapter(Type type);
+  boolean hasAdapter(Type type);
 
   /**
    * Build the Jsonb instance adding JsonAdapter, Factory or AdapterBuilder.

--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -369,6 +369,22 @@ public interface Jsonb {
   JsonAdapter<String> rawAdapter();
 
   /**
+   * Check if a JsonAdapter exists for the given class without attempting to create one.
+   * 
+   * @param cls The class to check for adapter availability
+   * @return true if an adapter exists or can be created, false otherwise
+   */
+  <T> boolean hasAdapter(Class<T> cls);
+
+  /**
+   * Check if a JsonAdapter exists for the given type without attempting to create one.
+   * 
+   * @param type The type to check for adapter availability  
+   * @return true if an adapter exists or can be created, false otherwise
+   */
+  <T> boolean hasAdapter(Type type);
+
+  /**
    * Build the Jsonb instance adding JsonAdapter, Factory or AdapterBuilder.
    */
   interface Builder {

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
@@ -64,14 +64,12 @@ final class CoreAdapterBuilder {
    * Check if an adapter exists or can be created for the given cache key.
    * If an adapter can be created, it will be cached for subsequent use.
    */
-  boolean hasAdapter(Object cacheKey) {
-    // Fast path: check if already cached
+  boolean hasAdapter(Type cacheKey) {
     if (adapterCache.containsKey(cacheKey)) {
       return true;
     }
 
-    // Try to create and cache adapter
-    JsonAdapter<?> adapter = tryCreateAdapter((Type) cacheKey, cacheKey, false);
+    JsonAdapter<?> adapter = lookupAdapter(cacheKey, cacheKey, false);
     return adapter != null;
   }
 
@@ -84,7 +82,7 @@ final class CoreAdapterBuilder {
    * @throws IllegalArgumentException if no adapter found and throwOnFailure is true
    */
   @SuppressWarnings("unchecked")
-  private <T> JsonAdapter<T> tryCreateAdapter(Type type, Object cacheKey, boolean throwOnFailure) {
+  private <T> JsonAdapter<T> lookupAdapter(Type type, Object cacheKey, boolean throwOnFailure) {
     LookupChain lookupChain = lookupChainThreadLocal.get();
     if (lookupChain == null) {
       lookupChain = new LookupChain();
@@ -138,7 +136,7 @@ final class CoreAdapterBuilder {
    * Build given type and annotations.
    */
   <T> JsonAdapter<T> build(Type type, Object cacheKey) {
-    return tryCreateAdapter(type, cacheKey, true);
+    return lookupAdapter(type, cacheKey, true);
   }
 
   /**

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
@@ -68,9 +68,7 @@ final class CoreAdapterBuilder {
     if (adapterCache.containsKey(cacheKey)) {
       return true;
     }
-
-    JsonAdapter<?> adapter = lookupAdapter(cacheKey, cacheKey, false);
-    return adapter != null;
+    return lookupAdapter(cacheKey, cacheKey, false) != null;
   }
 
   /**
@@ -108,11 +106,11 @@ final class CoreAdapterBuilder {
 
       if (throwOnFailure) {
         throw new IllegalArgumentException(
-            "No JsonAdapter for "
-                + type
-                + "\nPossible Causes: \n"
-                + "1. Missing @Json or @Json.Import annotation.\n"
-                + "2. The avaje-jsonb-generator dependency was not available during compilation\n");
+          "No JsonAdapter for "
+            + type
+            + "\nPossible Causes: \n"
+            + "1. Missing @Json or @Json.Import annotation.\n"
+            + "2. The avaje-jsonb-generator dependency was not available during compilation\n");
       }
       return null;  // No adapter found
     } catch (IllegalArgumentException e) {

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CoreAdapterBuilder.java
@@ -61,6 +61,25 @@ final class CoreAdapterBuilder {
   }
 
   /**
+   * Check if an adapter exists or can be created for the given cache key.
+   * This performs a lightweight check without creating or caching adapters.
+   */
+  boolean hasAdapter(Object cacheKey) {
+    // Fast path: check if already cached
+    if (adapterCache.containsKey(cacheKey)) {
+      return true;
+    }
+
+    // Check if any factory can create this adapter
+    for (AdapterFactory factory : factories) {
+      if (factory.create((Type) cacheKey, context) == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Build for the simple non-annotated type case.
    */
   <T> JsonAdapter<T> build(Type type) {

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -212,6 +212,18 @@ final class DJsonb implements Jsonb {
     return RawAdapter.STR;
   }
 
+  @Override
+  public <T> boolean hasAdapter(Class<T> cls) {
+    Type cacheKey = canonicalizeClass(requireNonNull(cls));
+    return builder.hasAdapter(cacheKey);
+  }
+
+  @Override
+  public <T> boolean hasAdapter(Type type) {
+    type = removeSubtypeWildcard(canonicalize(requireNonNull(type)));
+    return builder.hasAdapter(type);
+  }
+
   JsonReader objectReader(Object value) {
     return new ObjectJsonReader(value);
   }

--- a/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/DJsonb.java
@@ -213,13 +213,13 @@ final class DJsonb implements Jsonb {
   }
 
   @Override
-  public <T> boolean hasAdapter(Class<T> cls) {
+  public boolean hasAdapter(Class<?> cls) {
     Type cacheKey = canonicalizeClass(requireNonNull(cls));
     return builder.hasAdapter(cacheKey);
   }
 
   @Override
-  public <T> boolean hasAdapter(Type type) {
+  public boolean hasAdapter(Type type) {
     type = removeSubtypeWildcard(canonicalize(requireNonNull(type)));
     return builder.hasAdapter(type);
   }

--- a/jsonb/src/test/java/io/avaje/jsonb/core/HasAdapterTest.java
+++ b/jsonb/src/test/java/io/avaje/jsonb/core/HasAdapterTest.java
@@ -1,0 +1,71 @@
+package io.avaje.jsonb.core;
+
+import io.avaje.jsonb.Jsonb;
+import io.avaje.jsonb.Types;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HasAdapterTest {
+
+  private final Jsonb jsonb = Jsonb.builder().build();
+
+  @Test
+  @DisplayName("hasAdapter returns true for basic types and primitives")
+  void hasAdapter_basicTypes_returnsTrue() {
+    assertThat(jsonb.hasAdapter(String.class)).isTrue();
+    assertThat(jsonb.hasAdapter(Integer.class)).isTrue();
+    assertThat(jsonb.hasAdapter(Boolean.class)).isTrue();
+
+    assertThat(jsonb.hasAdapter(int.class)).isTrue();
+    assertThat(jsonb.hasAdapter(boolean.class)).isTrue();
+    assertThat(jsonb.hasAdapter(double.class)).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasAdapter returns true for generic types like List, Map, and Optional")
+  void hasAdapter_withGenericTypes_returnsTrue() {
+    Type listOfString = Types.listOf(String.class);
+    assertThat(jsonb.hasAdapter(listOfString)).isTrue();
+
+    Type mapOfStringToInteger = Types.mapOf(Integer.class);
+    assertThat(jsonb.hasAdapter(mapOfStringToInteger)).isTrue();
+
+    Type optionalString = Types.newParameterizedType(Optional.class, String.class);
+    assertThat(jsonb.hasAdapter(optionalString)).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasAdapter returns false for types without adapters")
+  void hasAdapter_whenAdapterNotExists_returnsFalse() {
+    assertThat(jsonb.hasAdapter(UnknownClass.class)).isFalse();
+    assertThat(jsonb.hasAdapter(SomeInterface.class)).isFalse();
+  }
+
+  @Test
+  @DisplayName("hasAdapter works correctly with cached adapters")
+  void hasAdapter_withCachedAdapter_returnsTrue() {
+    jsonb.type(String.class);
+    assertThat(jsonb.hasAdapter(String.class)).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasAdapter never throws exceptions, even for problematic types")
+  void hasAdapter_doesNotThrowExceptions() {
+    assertThat(jsonb.hasAdapter(UnknownClass.class)).isFalse();
+    assertThat(jsonb.hasAdapter(SomeInterface.class)).isFalse();
+  }
+
+  // Test classes
+  private static class UnknownClass {
+    private String value;
+  }
+
+  private interface SomeInterface {
+    String getValue();
+  }
+}


### PR DESCRIPTION
I took a crack at #414. 

I'm not sure if you think that this `hasAdapter` method should populate the cache. My thinking was that if you were doing this lookup, you'd want to get the adapter soon after. This avoid raising the exception and populating the stack trace and lookup stack if using `hasAdapter`.

