### PR TITLE
Fix Invalid `toJson` parameter name

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -360,7 +360,7 @@ final class ClassReader implements BeanReader {
   @Override
   public void writeToJson(Append writer) {
     try {
-      final String varName = Util.initLower(shortName);
+      final String varName = "$" + Util.initLower(shortName);
       writer.eol();
       writer.append("  @Override").eol();
       writer.append("  public void toJson(JsonWriter writer, %s %s) {", shortName, varName).eol();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -360,7 +360,7 @@ final class ClassReader implements BeanReader {
   @Override
   public void writeToJson(Append writer) {
     try {
-      final String varName = "$" + Util.initLower(shortName);
+      final String varName = "_" + Util.initLower(shortName);
       writer.eol();
       writer.append("  @Override").eol();
       writer.append("  public void toJson(JsonWriter writer, %s %s) {", shortName, varName).eol();

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/naming/PackageNaming.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/naming/PackageNaming.java
@@ -1,0 +1,28 @@
+package io.avaje.jsonb.generator.models.valid.naming;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public class PackageNaming {
+  private final Package queryPackage;
+
+  public PackageNaming(Package queryPackage) {
+    this.queryPackage = queryPackage;
+  }
+
+  public Package getQueryPackage() {
+    return queryPackage;
+  }
+
+  public static class Package {
+    private final String ecosystem;
+
+    public Package(String ecosystem) {
+      this.ecosystem = ecosystem;
+    }
+
+    public String getEcosystem() {
+      return ecosystem;
+    }
+  }
+}


### PR DESCRIPTION
If you happened to name a class `Package` or some other restricted java keyword, a compilation error would happen