### PR TITLE
Do not fail compilation on cascade failure

### DIFF
--- a/blackbox-test-cascade/pom.xml
+++ b/blackbox-test-cascade/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.avaje</groupId>
+    <artifactId>avaje-jsonb-parent</artifactId>
+    <version>3.8-RC1</version>
+  </parent>
+  <artifactId>blackbox-test-cascade</artifactId>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.compiler.release>21</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+
+    <!-- for testing fields with third party annotations -->
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>blackbox-test</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb-generator</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- test dependencies -->
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.6</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/blackbox-test-cascade/src/main/java/org/example/cascade/OtherJarJsonbCascade.java
+++ b/blackbox-test-cascade/src/main/java/org/example/cascade/OtherJarJsonbCascade.java
@@ -1,0 +1,8 @@
+package org.example.cascade;
+
+import org.example.customer.cascade.MCTop;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public record OtherJarJsonbCascade(MCTop top) {}

--- a/blackbox-test-cascade/src/main/java/org/example/cascade/UnCascadable.java
+++ b/blackbox-test-cascade/src/main/java/org/example/cascade/UnCascadable.java
@@ -1,0 +1,9 @@
+package org.example.cascade;
+
+import org.example.customer.cascade.CascadeNonAccessible;
+import org.example.customer.cascade.MCTop;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public record UnCascadable(MCTop top, CascadeNonAccessible access) {}

--- a/blackbox-test-cascade/src/test/java/org/example/cascade/TestCascade.java
+++ b/blackbox-test-cascade/src/test/java/org/example/cascade/TestCascade.java
@@ -1,0 +1,22 @@
+package org.example.cascade;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.Jsonb;
+
+class TestCascade {
+  static Jsonb jsonb = Jsonb.instance();
+
+  @Test
+  void testOtherJarCascade() {
+    assertDoesNotThrow(() -> jsonb.type(OtherJarJsonbCascade.class));
+  }
+
+  @Test
+  void failedCascade() {
+    assertThrows(IllegalArgumentException.class, () -> jsonb.type(UnCascadable.class));
+  }
+}

--- a/blackbox-test/src/main/java/module-info.java
+++ b/blackbox-test/src/main/java/module-info.java
@@ -7,6 +7,8 @@ module blackbox.test {
   requires java.validation;
   requires io.avaje.json.node;
 
+  exports org.example.customer.cascade;
+
   provides JsonbExtension
     with
       org.example.customer.customtype.CustomTypeComponent,

--- a/blackbox-test/src/main/java/org/example/customer/cascade/CascadeNonAccessible.java
+++ b/blackbox-test/src/main/java/org/example/customer/cascade/CascadeNonAccessible.java
@@ -1,0 +1,6 @@
+package org.example.customer.cascade;
+
+public class CascadeNonAccessible {
+
+ private final int id = 0;
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -243,7 +243,9 @@ public final class JsonbProcessor extends AbstractProcessor {
     for (final String type : extraTypes) {
       if (!ignoreType(type)) {
         final TypeElement element = typeElement(type);
-        if (element != null && element.getKind() != ElementKind.ENUM) {
+        if (element != null
+            && element.getKind() != ElementKind.ENUM
+            && !JsonPrism.isPresent(element)) {
           writeAdapterForType(element);
         }
       }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -246,6 +246,7 @@ public final class JsonbProcessor extends AbstractProcessor {
         if (element != null
             && element.getKind() != ElementKind.ENUM
             && !JsonPrism.isPresent(element)) {
+          ProcessingContext.cascadedType(type);
           writeAdapterForType(element);
         }
       }
@@ -371,10 +372,10 @@ public final class JsonbProcessor extends AbstractProcessor {
     }
     beanReader.read();
     if (beanReader.nonAccessibleField()) {
-      if (beanReader.hasJsonAnnotation()) {
+      if (beanReader.hasJsonAnnotation() && !ProcessingContext.isCascadeType(typeElement)) {
         logError("Error JsonAdapter due to nonAccessibleField for %s ", beanReader);
       }
-      logNote("Skipped writing JsonAdapter for %s due to non accessible fields", beanReader);
+      logNote(typeElement, "Skipped writing JsonAdapter for %s due to non accessible fields", beanReader);
       return;
     }
     try {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ProcessingContext.java
@@ -23,6 +23,7 @@ final class ProcessingContext {
 
   private static final class Ctx {
     private final Map<String, JsonPrism> importedJsonMap = new HashMap<>();
+    private final Set<String> cascadeSet = new HashSet<>();
     private final Map<String, List<SubTypePrism>> importedSubtypeMap = new HashMap<>();
     private final Set<String> services = new TreeSet<>();
     private final boolean injectPresent;
@@ -138,5 +139,17 @@ final class ProcessingContext {
       // not a critical error
     }
     return services;
+  }
+
+  public static void cascadedType(String type) {
+    CTX.get().cascadeSet.add(type);
+  }
+
+  public static boolean isCascadeType(TypeElement type) {
+    return isCascadeType(type.getQualifiedName().toString());
+  }
+
+  public static boolean isCascadeType(String type) {
+    return CTX.get().cascadeSet.contains(type);
   }
 }

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -3,6 +3,7 @@ package io.avaje.jsonb.generator;
 import static io.avaje.jsonb.generator.APContext.asTypeElement;
 import static io.avaje.jsonb.generator.APContext.logError;
 import static io.avaje.jsonb.generator.APContext.logNote;
+import static io.avaje.jsonb.generator.APContext.logWarn;
 import static io.avaje.jsonb.generator.APContext.typeElement;
 import static io.avaje.jsonb.generator.ProcessingContext.importedJson;
 import static java.util.stream.Collectors.toSet;
@@ -355,8 +356,24 @@ final class TypeReader {
     if (hasNoSetter(field)) {
       if (isCollectionType(field.type())) {
         field.setUseGetterAddAll();
+      } else if (ProcessingContext.isCascadeType(baseType)) {
+        nonAccessibleField = true;
+        logWarn(
+            field.element(),
+            errorContext
+                + baseType
+                + ", non public field "
+                + field.fieldName()
+                + " with no matching setter or constructor?");
+
       } else {
-        logError(errorContext + baseType + ", non public field " + field.fieldName() + " with no matching setter or constructor?");
+        logError(
+            field.element(),
+            errorContext
+                + baseType
+                + ", non public field "
+                + field.fieldName()
+                + " with no matching setter or constructor?");
       }
     }
   }

--- a/jsonb/src/main/java/io/avaje/jsonb/Json.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Json.java
@@ -7,6 +7,7 @@ import static java.lang.annotation.ElementType.MODULE;
 import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 import java.lang.annotation.Repeatable;
@@ -36,7 +37,7 @@ import io.avaje.jsonb.Json.Import.Imports;
  * }</pre>
  */
 @Target(TYPE)
-@Retention(SOURCE)
+@Retention(CLASS)
 public @interface Json {
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
       </activation>
       <modules>
         <module>blackbox-test</module>
+        <module>blackbox-test-cascade</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
- avoid cascading when the type has a `@Jsonb` annotation
- do not fail compilation if cascade type has non accessible fields (for situations with custom adapters)

resolves #433 and #434 