### PR TITLE
Generate Component Before The Last Round

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -135,12 +135,12 @@ public final class JsonbProcessor extends AbstractProcessor {
   }
 
   // Optional because annotations are not guaranteed to exist
-  private Optional<? extends Set<? extends Element>> getElements(
-      RoundEnvironment round, String name) {
+  private Optional<? extends Set<? extends Element>> getElements(RoundEnvironment round, String name) {
     var op =
-        Optional.ofNullable(typeElement(name))
-            .map(round::getElementsAnnotatedWith)
-            .filter(n -> !n.isEmpty());
+      Optional.ofNullable(typeElement(name))
+        .map(round::getElementsAnnotatedWith)
+        .filter(n -> !n.isEmpty());
+    // skip generateComponent if anything needs processing in this round
     generateComponent = generateComponent && op.isEmpty();
     return op;
   }
@@ -254,6 +254,7 @@ public final class JsonbProcessor extends AbstractProcessor {
     }
     for (final String type : extraTypes) {
       if (!ignoreType(type)) {
+        // skip generateComponent for this round due to cascade
         generateComponent = false;
         final TypeElement element = typeElement(type);
         if (element != null


### PR DESCRIPTION
Now if not on the first compilation round, checks whether there have been any processed jsonb annotations to generate a component. This prevents issues with `ModuleElement#getDirectives`


Resolves https://github.com/avaje/avaje-jsonb/issues/449