### PR TITLE
[bug fix] #464 fix missing comma in toJson for nested arrays

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/nesting/MyNestedList.java
+++ b/blackbox-test/src/main/java/org/example/customer/nesting/MyNestedList.java
@@ -1,0 +1,9 @@
+package org.example.customer.nesting;
+
+import io.avaje.jsonb.Json;
+
+import java.util.List;
+
+@Json
+public record MyNestedList(List<List<Long>> nestedInts) {
+}

--- a/blackbox-test/src/test/java/org/example/customer/nesting/MyNestedListTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/nesting/MyNestedListTest.java
@@ -1,0 +1,26 @@
+package org.example.customer.nesting;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyNestedListTest {
+
+  JsonType<MyNestedList> jsonb = Jsonb.instance().type(MyNestedList.class);
+
+  @Test
+  void toJson_fromJson() {
+    var nested = new MyNestedList(List.of(List.of(1L, 2L, 3L), List.of(8L, 9L)));
+    String asJson = jsonb.toJson(nested);
+    assertThat(asJson).isEqualTo("{\"nestedInts\":[[1,2,3],[8,9]]}");
+
+    MyNestedList myNestedList = jsonb.fromJson(asJson);
+    assertThat(myNestedList.nestedInts()).hasSize(2);
+    assertThat(myNestedList.nestedInts().get(0)).contains(1L, 2L, 3L);
+    assertThat(myNestedList.nestedInts().get(1)).contains(8L, 9L);
+  }
+}

--- a/json-core/src/main/java/io/avaje/json/stream/core/JGenerator.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JGenerator.java
@@ -546,6 +546,9 @@ class JGenerator implements JsonGenerator {
 
   @Override
   public void startArray() {
+    if (lastOp == OP_END) {
+      writeByte(COMMA);
+    }
     writeByte(ARRAY_START);
     lastOp = OP_START;
     if (pretty) {

--- a/json-node/src/test/java/io/avaje/json/node/JsonArrayTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/JsonArrayTest.java
@@ -145,4 +145,14 @@ class JsonArrayTest {
     assertThat(plain.get(1)).isEqualTo(Map.of("b", 42));
   }
 
+  @Test
+  void toJson_nested_array() {
+    JsonArray top = JsonArray.create()
+      .add(JsonArray.create().add("a"))
+      .add(JsonArray.create().add("b"));
+
+    String asJson = mapper.toJson(top);
+    assertThat(asJson).isEqualTo("[[\"a\"],[\"b\"]]");
+  }
+
 }


### PR DESCRIPTION
With arrays of arrays, the toJson content is missing a comma between the nested arrays.

The fix is in JGenerator.startArray() to add the missing comma prefix when the prior written "value" ended in a OP_END.