### PR TITLE
JsonProperty/Unmapped Setter Support

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/setter/PropertySetter.java
+++ b/blackbox-test/src/main/java/org/example/customer/setter/PropertySetter.java
@@ -1,0 +1,32 @@
+package org.example.customer.setter;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public class PropertySetter {
+
+  private long id;
+  private String name;
+
+  public long id() {
+    return id;
+  }
+
+  public PropertySetter id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  @Json.Property("full_name")
+  public PropertySetter name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  @Json.Property("void")
+  public void voided(String name) {}
+}

--- a/blackbox-test/src/main/java/org/example/customer/unmapped/UnmappedSetter.java
+++ b/blackbox-test/src/main/java/org/example/customer/unmapped/UnmappedSetter.java
@@ -1,0 +1,41 @@
+package org.example.customer.unmapped;
+
+import io.avaje.jsonb.Json;
+
+import java.util.Map;
+
+@Json
+public class UnmappedSetter {
+
+  private long id;
+  private String name;
+  private Map<String, Object> extra;
+
+  public long id() {
+    return id;
+  }
+
+  public UnmappedSetter id(long id) {
+    this.id = id;
+    return this;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public UnmappedSetter name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Map<String, Object> extra() {
+    return extra;
+  }
+
+  @Json.Unmapped
+  public UnmappedSetter extra(Map<String, Object> extra) {
+    this.extra = extra;
+    return this;
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/setter/PropertySetterTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/setter/PropertySetterTest.java
@@ -1,0 +1,30 @@
+package org.example.customer.setter;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PropertySetterTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<PropertySetter> jsonType = jsonb.type(PropertySetter.class);
+
+  @Test
+  void toJson_usesRenamedProperty() {
+    PropertySetter bean = new PropertySetter().id(1).name("Rob");
+
+    String asJson = jsonType.toJson(bean);
+
+    assertThat(asJson).isEqualTo("{\"id\":1,\"full_name\":\"Rob\"}");
+  }
+
+  @Test
+  void fromJson_usesRenamedProperty() {
+    PropertySetter bean = jsonType.fromJson("{\"id\":1,\"full_name\":\"Rob\"}");
+
+    assertThat(bean.id()).isEqualTo(1L);
+    assertThat(bean.name()).isEqualTo("Rob");
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/unmapped/UnmappedSetterTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/unmapped/UnmappedSetterTest.java
@@ -1,0 +1,42 @@
+package org.example.customer.unmapped;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnmappedSetterTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<UnmappedSetter> jsonType = jsonb.type(UnmappedSetter.class);
+
+  @Test
+  void toJson_unmappedSetter_includedInJson() {
+    Map<String, Object> extra = new LinkedHashMap<>();
+    extra.put("xone", 57);
+    extra.put("xtwo", "hello");
+
+    UnmappedSetter bean = new UnmappedSetter().id(42).name("foo").extra(extra);
+
+    String asJson = jsonType.toJson(bean);
+
+    assertThat(asJson).isEqualTo("{\"id\":42,\"name\":\"foo\",\"xone\":57,\"xtwo\":\"hello\"}");
+  }
+
+  @Test
+  void fromJson_unmappedSetter_unknownFieldsCollected() {
+    String jsonContent = "{\"id\":42,\"name\":\"foo\",\"xone\":57,\"xtwo\":\"hello\"}";
+
+    UnmappedSetter bean = jsonType.fromJson(jsonContent);
+
+    assertThat(bean.id()).isEqualTo(42L);
+    assertThat(bean.name()).isEqualTo("foo");
+    assertThat(bean.extra()).containsKeys("xone", "xtwo");
+    assertThat(bean.extra()).containsEntry("xone", 57L);
+    assertThat(bean.extra()).containsEntry("xtwo", "hello");
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
@@ -10,18 +10,17 @@ import javax.lang.model.type.TypeMirror;
 
 final class FieldProperty {
 
-  private Element element;
   private final boolean raw;
-  private final boolean unmapped;
+  private boolean unmapped;
   private final String rawType;
   private final boolean publicField;
   private final String fieldName;
   private final List<String> genericTypeParams;
 
-  private final GenericType genericType;
-  private final String adapterFieldName;
-  private final String adapterShortType;
-  private final String defaultValue;
+  private GenericType genericType;
+  private String adapterFieldName;
+  private String adapterShortType;
+  private String defaultValue;
   private final boolean optional;
   private boolean genericTypeParameter;
   private int genericTypeParamPosition;
@@ -51,7 +50,6 @@ final class FieldProperty {
       boolean publicField,
       String fieldName,
       Optional<TypeMirror> customSerializer) {
-    this.element = element;
     this.raw = raw;
     this.unmapped = unmapped;
     this.publicField = publicField;
@@ -97,6 +95,20 @@ final class FieldProperty {
 
   void setConstructorParam() {
     constructorParam = true;
+  }
+
+  void setAsUnmapped() {
+    this.unmapped = true;
+    if (unmappedJsonObject()) {
+      this.genericType = GenericType.parse("io.avaje.json.node.JsonNode");
+      this.adapterShortType = "JsonAdapter<JsonNode>";
+      this.adapterFieldName = "jsonNodeAdapter";
+    } else {
+      this.genericType = GenericType.parse("java.lang.Object");
+      this.adapterShortType = "JsonAdapter<Object>";
+      this.adapterFieldName = "objectJsonAdapter";
+    }
+    this.defaultValue = "null";
   }
 
   void setPosition(int pos) {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldReader.java
@@ -13,10 +13,10 @@ final class FieldReader {
 
   private final Element element;
   private final FieldProperty property;
-  private final String propertyName;
-  private final boolean serialize;
+  private String propertyName;
+  private boolean serialize;
   private boolean deserialize;
-  private final boolean unmapped;
+  private boolean unmapped;
   private final boolean raw;
   private final boolean hasCustomSerializer;
 
@@ -25,6 +25,7 @@ final class FieldReader {
   private final String num;
   private boolean isCreatorParam;
   private boolean useGetterAddAll;
+  private boolean orphanUnmappedSetter;
 
   FieldReader(
       Element element,
@@ -135,6 +136,27 @@ final class FieldReader {
 
   boolean isUnmapped() {
     return unmapped;
+  }
+
+  void enableSerialize() {
+    this.serialize = true;
+  }
+
+  void setAsUnmapped() {
+    this.unmapped = true;
+    this.property.setAsUnmapped();
+  }
+
+  void overridePropertyName(String name) {
+    this.propertyName = name;
+  }
+
+  void setOrphanUnmappedSetter() {
+    this.orphanUnmappedSetter = true;
+  }
+
+  boolean isOrphanUnmappedSetter() {
+    return orphanUnmappedSetter;
   }
 
   boolean include() {

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -49,6 +49,8 @@ final class TypeReader {
   private final Map<String, MethodReader> maybeGetterMethods = new LinkedHashMap<>();
   private final Map<String, MethodReader> allGetterMethods = new LinkedHashMap<>();
   private final Map<String, MethodReader> allSetterMethods = new LinkedHashMap<>();
+  private final Map<String, MethodReader> unmappedSetterMethods = new LinkedHashMap<>();
+  private final Map<String, String> propertySetterMethods = new LinkedHashMap<>();
 
   private final TypeSubTypeReader subTypes;
   private final TypeElement baseType;
@@ -318,6 +320,14 @@ final class TypeReader {
       final String methodKey = methodElement.getSimpleName().toString();
       MethodReader methodReader = new MethodReader(methodElement).read();
       if (parameters.size() == 1) {
+        var param = (VariableElement) parameters.get(0);
+        if (UnmappedPrism.isPresent(methodElement) || UnmappedPrism.isPresent(param)) {
+          unmappedSetterMethods.put(methodKey, methodReader);
+        }
+        PropertyPrism.getOptionalOn(methodElement)
+          .map(PropertyPrism::value)
+          .map(Util::escapeQuotes)
+          .ifPresent(propName -> propertySetterMethods.put(methodKey, propName));
         maybeSetterMethods.putIfAbsent(methodKey, methodReader);
         allSetterMethods.put(methodKey.toLowerCase(), methodReader);
       } else if (parameters.isEmpty()) {
@@ -328,15 +338,11 @@ final class TypeReader {
         }
       }
     }
-    // for getter/accessor methods only, not setters
+    // for getter/accessor methods only (setter case handled via propertySetterMethods)
     PropertyPrism.getOptionalOn(methodElement)
       .filter(p -> !hasRecordPropertyAnnotation(methodElement))
+      .filter(p -> methodElement.getParameters().isEmpty())
       .ifPresent(propertyPrism -> {
-        if (!methodElement.getParameters().isEmpty()) {
-          logError(errorContext + baseType + ", @Json.Property can only be placed on Getter Methods, but on %s", methodElement);
-          return;
-        }
-
         // getter property as simulated read-only field with getter method
         final var frequency = frequency(propertyPrism.value());
         final var reader = new FieldReader(element, namingConvention, currentSubType, genericTypeParams, frequency);
@@ -477,11 +483,95 @@ final class TypeReader {
     return maybeSetterMethods.get(name);
   }
 
+  private void upgradeFieldsWithUnmappedSetters() {
+    if (unmappedSetterMethods.isEmpty()) return;
+    for (FieldReader field : allFields) {
+      if (!field.isUnmapped() && field.setter() != null) {
+        var matched = unmappedSetterMethods.remove(field.setter().getName());
+        if (matched != null) {
+          field.setAsUnmapped();
+        }
+      }
+    }
+  }
+
+  private void upgradeFieldsWithPropertySetters() {
+    if (propertySetterMethods.isEmpty()) return;
+    for (FieldReader field : allFields) {
+      if (field.setter() != null) {
+        var propName = propertySetterMethods.remove(field.setter().getName());
+        if (propName != null) {
+          field.overridePropertyName(propName);
+        }
+      }
+    }
+  }
+
+  private void createOrphanUnmappedSetterFields() {
+    for (MethodReader setter : unmappedSetterMethods.values()) {
+      var setterElement = setter.element();
+      var param = (VariableElement) setterElement.getParameters().get(0);
+      final var frequency = frequency(param.getSimpleName().toString());
+      FieldReader unmappedReader =
+          new FieldReader(
+              param,
+              null,
+              namingConvention,
+              currentSubType,
+              genericTypeParams,
+              frequency,
+              hasJsonCreator);
+      unmappedReader.setAsUnmapped();
+      unmappedReader.setOrphanUnmappedSetter();
+      unmappedReader.setterMethod(setter);
+      allFields.add(unmappedReader);
+      allFieldMap.put(
+          unmappedReader.fieldName() + unmappedReader.adapterShortType(), unmappedReader);
+    }
+    unmappedSetterMethods.clear();
+    // Orphan property-setter: setter with @Json.Property but no matching backing field
+    for (Map.Entry<String, String> entry : propertySetterMethods.entrySet()) {
+      var setter = maybeSetterMethods.get(entry.getKey());
+      if (setter == null) continue;
+      var setterElement = setter.element();
+      var param = (VariableElement) setterElement.getParameters().get(0);
+      final var frequency = frequency(entry.getValue());
+      FieldReader orphanReader =
+          new FieldReader(
+              param,
+              null,
+              namingConvention,
+              currentSubType,
+              genericTypeParams,
+              frequency,
+              hasJsonCreator);
+      orphanReader.overridePropertyName(entry.getValue());
+      orphanReader.setterMethod(setter);
+      allFields.add(orphanReader);
+      allFieldMap.put(orphanReader.fieldName() + orphanReader.adapterShortType(), orphanReader);
+    }
+    propertySetterMethods.clear();
+  }
+
   private void matchFieldsToGetter() {
     for (FieldReader field : allFields) {
       if (field.includeToJson()) {
         matchFieldToGetter(field);
+      } else if (field.isOrphanUnmappedSetter()) {
+        // Orphan unmapped setter (no backing field): try to find a getter for round-trip serialization
+        tryMatchUnmappedGetter(field);
       }
+    }
+  }
+
+  private void tryMatchUnmappedGetter(FieldReader field) {
+    var fieldName = field.fieldName();
+    var propName = field.propertyName();
+    if (matchGetter(fieldName, field, false)
+        || matchGetter(fieldName, field, true)
+        || matchGetter(propName, field, false)
+        || matchGetter(propName, field, true)) {
+      field.enableSerialize();
     }
   }
 
@@ -665,6 +755,9 @@ final class TypeReader {
       }
     }
     matchFieldsToSetterOrConstructor();
+    upgradeFieldsWithUnmappedSetters();
+    upgradeFieldsWithPropertySetters();
+    createOrphanUnmappedSetterFields();
     matchFieldsToGetter();
     if (extendsThrowable || allFields.isEmpty() && subTypes.subTypes().isEmpty()) {
       initReadOnlyMethods();


### PR DESCRIPTION
Support @Json.Unmapped on setter methods                                                                                                                         
                                                                                                                                                              
 Previously only supported on fields and constructor/factory parameters. Now also works on setter methods (or their parameters). 
  Two sub-cases handled:                                                                                                                                          
  - Setter with backing field - the field is "upgraded" to unmapped mode: unknown JSON properties are collected into a LinkedHashMap/JsonObject and passed to 
  the setter after deserialization.

```java
  private Map<String, Object> extra;                                                                                                                          
  public Map<String, Object> extra() { return extra; }                                                                                                        
   
  @Json.Unmapped                                                                                                                                              
  public Foo extra(Map<String, Object> extra) { this.extra = extra; return this; }
```
  - Orphan setter (no backing field) - a synthetic FieldReader is created from the setter's parameter. Getter matching is attempted; if found, round-trip     
  serialization is enabled; if not, the setter is write-only (deserialize-only).                                                                              
                                                                                                                                                              
  ---                                                                                                                                                         
Support  @Json.Property("name") on setter methods               
                                                                                             
  Two sub-cases handled:
                                                                                                                                                              
  - Setter with backing field - the field's JSON property name is overridden. Both serialization (via the getter) and deserialization (via the setter) use the
   new name.

```java
  private String name;                                                                                                                                        
  public String name() { return name; }                     

  @Json.Property("full_name")                                                                                                                                 
  public Foo name(String name) { this.name = name; return this; }
  //  JSON key is "full_name" in both toJson and fromJson 
```                                                                                                 
  - Orphan setter (no backing field) - a write-only entry is created with the renamed property name (deserialize-only via the setter, no serialization without
   a matching getter).
```java                                                                                                                           
  @Json.Property("void")                                                                                                                                      
  public void voided(String name) {}                                                                                                                          
  //  reads "void" from JSON and calls voided(); no serialization output                                                                                     
```                         


Resolves #517 

