### PR TITLE
Fix Inherited Setter Properties

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/subtype/Machine.java
+++ b/blackbox-test/src/main/java/org/example/customer/subtype/Machine.java
@@ -1,0 +1,41 @@
+package org.example.customer.subtype;
+
+import org.example.customer.subtype.Machine.V1;
+import org.example.customer.subtype.Machine.V2;
+
+import io.avaje.jsonb.Json;
+
+@Json
+@Json.SubType(type = V1.class)
+@Json.SubType(type = V2.class)
+public class Machine {
+  public String name;
+
+  @Json.Property("rank")
+  public String style() {
+    return "ULTRAKILL";
+  }
+
+  @Json.Property("bloodType")
+  public void bloodType(String bloodType) {
+    name = bloodType;
+  }
+
+  public static class V1 extends Machine {
+    public String arm = "Feedbacker";
+
+    @Json.Property("altFire")
+    public void altFire(String altFire) {
+      name = altFire;
+    }
+  }
+
+  public static class V2 extends Machine {
+    public String arm = "Knuckleblaster";
+
+    @Json.Property("altFire")
+    public void altFire(String altFire) {
+      name = altFire;
+    }
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/subtype/SubTypeSetterTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/subtype/SubTypeSetterTest.java
@@ -1,0 +1,41 @@
+package org.example.customer.subtype;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubTypeSetterTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<Machine> type = jsonb.type(Machine.class);
+
+  @Test
+  void v1_bloodTypeSetter_applied() {
+    Machine result = type.fromJson("{\"@type\":\"Machine.V1\",\"bloodType\":\"hello\"}");
+    assertThat(result).isInstanceOf(Machine.V1.class);
+    assertThat(result.name).isEqualTo("hello");
+  }
+
+  @Test
+  void v2_bloodTypeSetter_applied() {
+    Machine result = type.fromJson("{\"@type\":\"Machine.V2\",\"bloodType\":\"world\"}");
+    assertThat(result).isInstanceOf(Machine.V2.class);
+    assertThat(result.name).isEqualTo("world");
+  }
+
+  @Test
+  void v1_altFireSetter_applied() {
+    Machine result = type.fromJson("{\"@type\":\"Machine.V1\",\"altFire\":\"foo\"}");
+    assertThat(result).isInstanceOf(Machine.V1.class);
+    assertThat(result.name).isEqualTo("foo");
+  }
+
+  @Test
+  void v2_altFireSetter_applied() {
+    Machine result = type.fromJson("{\"@type\":\"Machine.V2\",\"altFire\":\"bar\"}");
+    assertThat(result).isInstanceOf(Machine.V2.class);
+    assertThat(result.name).isEqualTo("bar");
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeReader.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +52,7 @@ final class TypeReader {
   private final Map<String, MethodReader> allSetterMethods = new LinkedHashMap<>();
   private final Map<String, MethodReader> unmappedSetterMethods = new LinkedHashMap<>();
   private final Map<String, String> propertySetterMethods = new LinkedHashMap<>();
+  private final Map<String, Set<TypeSubTypeMeta>> setterSubTypes = new LinkedHashMap<>();
 
   private final TypeSubTypeReader subTypes;
   private final TypeElement baseType;
@@ -333,6 +335,7 @@ final class TypeReader {
           .ifPresent(propName -> propertySetterMethods.put(methodKey, propName));
         maybeSetterMethods.putIfAbsent(methodKey, methodReader);
         allSetterMethods.put(methodKey.toLowerCase(), methodReader);
+        setterSubTypes.computeIfAbsent(methodKey, k -> new LinkedHashSet<>()).add(currentSubType);
       } else if (parameters.isEmpty()) {
         TypeMirror returnType = methodElement.getReturnType();
         if (!"void".equals(returnType.toString())) {
@@ -524,18 +527,24 @@ final class TypeReader {
       var setterElement = setter.element();
       var param = (VariableElement) setterElement.getParameters().get(0);
       final var frequency = frequency(param.getSimpleName().toString());
+      final var methodKey = setterElement.getSimpleName().toString();
+      final var subtypesForSetter = setterSubTypes.getOrDefault(methodKey, Set.of());
+      final var firstSubType = subtypesForSetter.stream().filter(st -> st != null).findFirst().orElse(null);
       FieldReader unmappedReader =
           new FieldReader(
               param,
               null,
               namingConvention,
-              currentSubType,
+              firstSubType,
               genericTypeParams,
               frequency,
               hasJsonCreator);
       unmappedReader.setAsUnmapped();
       unmappedReader.setOrphanUnmappedSetter();
       unmappedReader.setterMethod(setter);
+      for (TypeSubTypeMeta subType : subtypesForSetter) {
+        unmappedReader.addSubType(subType);
+      }
       allFields.add(unmappedReader);
       allFieldMap.put(
           unmappedReader.fieldName() + unmappedReader.adapterShortType(), unmappedReader);
@@ -558,21 +567,27 @@ final class TypeReader {
         continue;
       }
       final var frequency = frequency(entry.getValue());
+      final var subtypesForSetter = setterSubTypes.getOrDefault(entry.getKey(), Set.of());
+      final var firstSubType = subtypesForSetter.stream().filter(st -> st != null).findFirst().orElse(null);
       FieldReader orphanReader =
           new FieldReader(
               param,
               null,
               namingConvention,
-              currentSubType,
+              firstSubType,
               genericTypeParams,
               frequency,
               hasJsonCreator);
       orphanReader.overridePropertyName(entry.getValue());
       orphanReader.setterMethod(setter);
+      for (TypeSubTypeMeta subType : subtypesForSetter) {
+        orphanReader.addSubType(subType);
+      }
       allFields.add(orphanReader);
       allFieldMap.put(orphanReader.fieldName() + orphanReader.adapterShortType(), orphanReader);
     }
     propertySetterMethods.clear();
+    setterSubTypes.clear();
   }
 
   private void matchFieldsToGetter() {

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/Machine.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/Machine.java
@@ -1,0 +1,38 @@
+package io.avaje.jsonb.generator.models.valid.subtype;
+
+import io.avaje.jsonb.Json;
+
+@Json
+@Json.SubType(type = Machine.V1.class)
+@Json.SubType(type = Machine.V2.class)
+public class Machine {
+  public String name;
+
+  @Json.Property("rank")
+  public String style() {
+    return "ULTRAKILL";
+  }
+
+  @Json.Property("bloodType")
+  public void bloodType(String bloodType) {
+    name = bloodType;
+  }
+
+  public static class V1 extends Machine {
+    public String arm = "Feedbacker";
+
+    @Json.Property("altFire")
+    public void altFire(String altFire) {
+      name = altFire;
+    }
+  }
+
+  public static class V2 extends Machine {
+    public String arm = "Knuckleblaster";
+
+    @Json.Property("altFire")
+    public void altFire(String altFire) {
+      name = altFire;
+    }
+  }
+}


### PR DESCRIPTION
Turns out that setter fields (those with no backing field) were constructed using only the last processed subtype.

resolves #527 