### PR TITLE
Prevent Unneeded Cascade

### DIFF
--- a/blackbox-test-cascade/src/main/java/module-info.java
+++ b/blackbox-test-cascade/src/main/java/module-info.java
@@ -1,3 +1,8 @@
+import org.example.other.custom.CustomClass;
+
+import io.avaje.jsonb.CustomAdapter.AdaptedTypes;
+
+@AdaptedTypes(CustomClass.class)
 module blackbox.test.cascade {
 
   requires static io.avaje.jsonb;

--- a/blackbox-test-cascade/src/main/java/module-info.java
+++ b/blackbox-test-cascade/src/main/java/module-info.java
@@ -1,8 +1,6 @@
-import org.example.other.custom.CustomClass;
 
-import io.avaje.jsonb.CustomAdapter.AdaptedTypes;
 
-@AdaptedTypes(CustomClass.class)
+//@AdaptedTypes(CustomClass.class)
 module blackbox.test.cascade {
 
   requires static io.avaje.jsonb;

--- a/blackbox-test-cascade/src/main/java/org/cascade/custom/WithExternalCustomAdapter.java
+++ b/blackbox-test-cascade/src/main/java/org/cascade/custom/WithExternalCustomAdapter.java
@@ -1,0 +1,7 @@
+package org.cascade.custom;
+
+import io.avaje.jsonb.Json;
+import org.example.other.custom.CustomClass;
+
+@Json
+public record WithExternalCustomAdapter(String name, CustomClass custom) {}

--- a/blackbox-test-cascade/src/test/java/org/cascade/custom/WithExternalCustomAdapterTest.java
+++ b/blackbox-test-cascade/src/test/java/org/cascade/custom/WithExternalCustomAdapterTest.java
@@ -1,0 +1,23 @@
+package org.cascade.custom;
+
+import io.avaje.jsonb.Jsonb;
+import org.example.other.custom.CustomClass;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithExternalCustomAdapterTest {
+
+  @Test
+  void roundTrip() {
+    final var jsonb = Jsonb.builder().build();
+    final var value = new WithExternalCustomAdapter("hello", new CustomClass("world"));
+
+    final var json = jsonb.toJson(value);
+    assertThat(json).isEqualTo("{\"name\":\"hello\",\"custom\":{\"body\":\"world\"}}");
+
+    final var deserialized = jsonb.type(WithExternalCustomAdapter.class).fromJson(json);
+    assertThat(deserialized.name()).isEqualTo("hello");
+    assertThat(deserialized.custom().body()).isEqualTo("world");
+  }
+}

--- a/blackbox-test/src/main/java/module-info.java
+++ b/blackbox-test/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module blackbox.test {
   requires io.avaje.json.node;
 
   exports org.example.customer.cascade;
+  exports org.example.other.custom;
   exports org.example.imported;
 
   provides JsonbExtension

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ExternalModules.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ExternalModules.java
@@ -1,0 +1,74 @@
+package io.avaje.jsonb.generator;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+
+final class ExternalModules {
+
+  private static final Set<String> ADAPTED_TYPES = new HashSet<>();
+
+  private ExternalModules() {}
+
+  static boolean contains(String type) {
+    return ADAPTED_TYPES.contains(type);
+  }
+
+  static void readAdaptedTypes() {
+    var currentModule = APContext.getProjectModuleElement();
+    if (currentModule == null || currentModule.isUnnamed() || !ADAPTED_TYPES.isEmpty()) return;
+
+    var jsonbExtensionType = APContext.typeElement("io.avaje.jsonb.spi.JsonbExtension");
+    if (jsonbExtensionType == null) return;
+    var extensionTypeMirror = jsonbExtensionType.asType();
+
+    APContext.elements().getAllModuleElements().stream()
+      .filter(m -> !m.isUnnamed())
+      .filter(m -> !m.equals(currentModule))
+      .filter(m -> !m.getQualifiedName().toString().startsWith("java."))
+      .filter(m -> !m.getQualifiedName().toString().startsWith("jdk."))
+      .flatMap(m -> m.getDirectives().stream())
+      .filter(d -> d.getKind() == ModuleElement.DirectiveKind.PROVIDES)
+      .map(d -> (ModuleElement.ProvidesDirective) d)
+      .filter(d -> APContext.types().isAssignable(d.getService().asType(), extensionTypeMirror))
+      .flatMap(d -> d.getImplementations().stream())
+      .map(impl -> APContext.typeElement(impl.getQualifiedName().toString()))
+      .filter(Objects::nonNull)
+      .filter(ExternalModules::isGeneratedComponent)
+      .forEach(ExternalModules::readAdaptedTypesFromComponent);
+  }
+
+  private static boolean isGeneratedComponent(TypeElement te) {
+    var generatedType = APContext.typeElement("io.avaje.jsonb.spi.GeneratedComponent");
+    return generatedType != null
+      && APContext.types().isSubtype(te.asType(), generatedType.asType());
+  }
+
+  private static void readAdaptedTypesFromComponent(TypeElement component) {
+    for (var mirror : component.getAnnotationMirrors()) {
+      var prism = MetaDataPrism.getInstance(mirror);
+      if (prism == null) continue;
+      prism.value().stream()
+        .map(TypeMirror::toString)
+        .map(APContext::typeElement)
+        .filter(Objects::nonNull)
+        .forEach(ExternalModules::registerAdaptedType);
+    }
+  }
+
+  private static void registerAdaptedType(TypeElement adapterType) {
+    adapterType.getInterfaces().stream()
+      .filter(t -> t.toString().contains("io.avaje.json.JsonAdapter"))
+      .findFirst()
+      .ifPresent(t -> {
+        var adapted = UType.parse(t).param0().fullWithoutAnnotations();
+        if (adapted != null && !GenericType.isGeneric(adapted)) {
+          ADAPTED_TYPES.add(adapted);
+        }
+      });
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -48,6 +48,7 @@ import io.avaje.prism.GenerateUtils;
 @GenerateUtils
 @GenerateAPContext
 @SupportedAnnotationTypes({
+  AdaptedTypesPrism.PRISM_TYPE,
   CustomAdapterPrism.PRISM_TYPE,
   JSON,
   JSON_IMPORT,
@@ -131,6 +132,11 @@ public final class JsonbProcessor extends AbstractProcessor {
     getElements(round, CustomAdapterPrism.PRISM_TYPE).ifPresent(this::registerCustomAdapters);
 
     metaData.fullName(false);
+    getElements(round, AdaptedTypesPrism.PRISM_TYPE).stream()
+        .flatMap(Set::stream)
+        .map(AdaptedTypesPrism::getInstanceOn)
+        .flatMap(a -> a.value().stream().map(Object::toString))
+        .forEach(sourceTypes::add);
     cascadeTypes();
     writeComponent(generateComponent);
     return false;

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -254,6 +254,7 @@ public final class JsonbProcessor extends AbstractProcessor {
   }
 
   private void cascadeTypes() {
+    ExternalModules.readAdaptedTypes();
     while (!allReaders.isEmpty()) {
       cascadeTypesInner();
     }
@@ -288,7 +289,8 @@ public final class JsonbProcessor extends AbstractProcessor {
         || type.startsWith("javax.")
         || "io.avaje.json.node.JsonNode".equals(type)
         || sourceTypes.contains(type)
-        || writtenTypes.contains(type);
+        || writtenTypes.contains(type)
+        || ExternalModules.contains(type);
   }
 
   /**

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/package-info.java
@@ -1,4 +1,5 @@
 @GeneratePrism(io.avaje.jsonb.CustomAdapter.class)
+@GeneratePrism(io.avaje.jsonb.CustomAdapter.AdaptedTypes.class)
 @GeneratePrism(io.avaje.jsonb.Json.class)
 @GeneratePrism(io.avaje.jsonb.Json.Import.class)
 @GeneratePrism(io.avaje.jsonb.Json.Import.Imports.class)

--- a/jsonb/src/main/java/io/avaje/jsonb/CustomAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/CustomAdapter.java
@@ -1,8 +1,8 @@
 package io.avaje.jsonb;
 
-import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -57,7 +57,7 @@ import java.lang.annotation.Target;
  *
  * }</pre>
  */
-@Target(TYPE)
+@Target(ElementType.TYPE)
 @Retention(SOURCE)
 public @interface CustomAdapter {
 
@@ -66,4 +66,13 @@ public @interface CustomAdapter {
    * to use the adapter is via the {@link Json.Serializer} annotation
    */
   boolean global() default true;
+
+  /**
+   * This annotation can be used to specify types that are already adapted by external libraries,
+   * disabling cascade adapter generation for the provided types.
+   */
+  @Target({ElementType.TYPE, ElementType.MODULE, ElementType.PACKAGE})
+  public @interface AdaptedTypes {
+    Class<?>[] value();
+  }
 }


### PR DESCRIPTION
Resolves #529 in two ways

- adds an annnotation to disable cascade on a type
- when using jpms, auto-detect already generated adapters from other projects and disable cascade for types that already have one 