### PR TITLE
Switch from File to Path

### DIFF
--- a/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/CustomerTest.java
@@ -6,9 +6,10 @@ import io.avaje.jsonb.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 
@@ -72,15 +73,15 @@ class CustomerTest {
   @Test
   void anyToFile() throws Exception {
     var customer = new Customer().id(42L).name("rob").status(Customer.Status.ACTIVE);
-    File file = File.createTempFile("customer", ".json");
+    Path path = Files.createTempFile("customer", ".json");
     try {
-      jsonb.toJson(customer, file);
-      Customer fromFile = jsonb.type(Customer.class).fromJson(file);
+      jsonb.toJson(customer, path);
+      Customer fromFile = jsonb.type(Customer.class).fromJson(path);
       assertThat(fromFile.id()).isEqualTo(42L);
       assertThat(fromFile.name()).isEqualTo("rob");
       assertThat(fromFile.status()).isEqualTo(Customer.Status.ACTIVE);
     } finally {
-      file.delete();
+      Files.delete(path);
     }
   }
 
@@ -156,16 +157,16 @@ class CustomerTest {
   void toJson_file() throws Exception {
     Customer customer = customer();
     JsonType<Customer> customerType = jsonb.type(Customer.class);
-    File file = File.createTempFile("customer", ".json");
+    Path path = Files.createTempFile("customer", ".json");
     try {
-      customerType.toJson(customer, file);
-      Customer fromFile = customerType.fromJson(file);
+      customerType.toJson(customer, path);
+      Customer fromFile = customerType.fromJson(path);
       assertThat(fromFile.id()).isEqualTo(customer.id());
       assertThat(fromFile.name()).isEqualTo(customer.name());
       assertThat(fromFile.status()).isEqualTo(customer.status());
       assertThat(fromFile.whenCreated()).isEqualTo(customer.whenCreated());
     } finally {
-      file.delete();
+      Files.delete(path);
     }
   }
 

--- a/jsonb/src/main/java/io/avaje/jsonb/JsonType.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/JsonType.java
@@ -3,12 +3,12 @@ package io.avaje.jsonb;
 import io.avaje.json.JsonReader;
 import io.avaje.json.mapper.JsonMapper;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  *
  * <h4>fromJson</h4>
  * <p>
- * Read json content from: String, byte[], Reader, InputStream, File, JsonReader
+ * Read json content from: String, byte[], Reader, InputStream, Path, JsonReader
  * </p>
  * <pre>{@code
  *
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
  *
  * <h4>toJson</h4>
  * <p>
- * Write json content to: String, byte[], Writer, OutputStream, File, JsonWriter
+ * Write json content to: String, byte[], Writer, OutputStream, Path, JsonWriter
  * </p>
  * <pre>{@code
  *
@@ -152,10 +152,10 @@ public interface JsonType<T> extends JsonView<T>, JsonMapper.Type<T> {
   T fromJson(InputStream inputStream);
 
   /**
-   * Read and return the value from the file.
+   * Read and return the value from the path.
    */
-  default T fromJson(File file) {
-    try (InputStream inputStream = new FileInputStream(file)) {
+  default T fromJson(Path path) {
+    try (InputStream inputStream = Files.newInputStream(path)) {
       return fromJson(inputStream);
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/jsonb/src/main/java/io/avaje/jsonb/JsonView.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/JsonView.java
@@ -3,12 +3,12 @@ package io.avaje.jsonb;
 import io.avaje.json.stream.JsonOutput;
 import io.avaje.json.JsonWriter;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * Represents a subset of properties that can be written as json.
@@ -67,10 +67,10 @@ public interface JsonView<T> {
   void toJson(T value, OutputStream outputStream);
 
   /**
-   * Write to the given file.
+   * Write to the given path.
    */
-  default void toJson(T value, File file) {
-    try (FileOutputStream outputStream = new FileOutputStream(file)) {
+  default void toJson(T value, Path path) {
+    try (OutputStream outputStream = Files.newOutputStream(path)) {
       toJson(value, outputStream);
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/Jsonb.java
@@ -1,11 +1,11 @@
 package io.avaje.jsonb;
 
-import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.lang.reflect.Type;
+import java.nio.file.Path;
 import java.util.function.Supplier;
 
 import io.avaje.json.JsonAdapter;
@@ -160,12 +160,12 @@ public interface Jsonb {
   void toJson(Object any, OutputStream outputStream);
 
   /**
-   * Write to the given file.
+   * Write to the given path.
    * <p>
-   * This is a convenience method for {@code jsonb.type(Object.class).toJson(any, file) }
+   * This is a convenience method for {@code jsonb.type(Object.class).toJson(any, path) }
    */
-  default void toJson(Object any, File file) {
-    type(Object.class).toJson(any, file);
+  default void toJson(Object any, Path path) {
+    type(Object.class).toJson(any, path);
   }
 
   /**


### PR DESCRIPTION
This changes the new methods in #535 to accept `java.nio.file.Path` instead of `java.io.File` since it is newer and functionally equivalent.