### PR TITLE
Bounded collection serialization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,7 @@ public final class AddressJsonAdapter implements JsonAdapter<Address>, ViewBuild
 
   @Override
   public void toJson(JsonWriter writer, Address address) {
-    writer.beginObject(names);
-    writer.names(names);
+    writer.beginObject(names, 3);
     writer.name(0);
     stringJsonAdapter.toJson(writer, address.getStreet());
     writer.name(1);

--- a/bench-jmh/src/main/java/org/example/jmh/MyCustomNarrowAdapter.java
+++ b/bench-jmh/src/main/java/org/example/jmh/MyCustomNarrowAdapter.java
@@ -26,8 +26,7 @@ public class MyCustomNarrowAdapter implements JsonAdapter<NarrowNamesRecord> {
 
   @Override
   public void toJson(JsonWriter writer, NarrowNamesRecord myRecord) {
-    writer.beginObject();
-    //writer.names(names);
+    writer.beginObject(5);
     //writer.name(0);
     writer.name("a");
     stringJsonAdapter.toJson(writer, myRecord.a());

--- a/bench-jmh/src/main/java/org/example/jmh/MyCustomWideAdapter.java
+++ b/bench-jmh/src/main/java/org/example/jmh/MyCustomWideAdapter.java
@@ -27,9 +27,7 @@ public class MyCustomWideAdapter implements JsonAdapter<WideNamesRecord> {
 
   @Override
   public void toJson(JsonWriter writer, WideNamesRecord myRecord) {
-    writer.beginObject();
-    //writer.names(names);
-    //writer.name(0);
+    writer.beginObject(5);
     writer.name("firstNameProperty1");
     stringJsonAdapter.toJson(writer, myRecord.firstNameProperty1());
     writer.name("lastNameProperty2");

--- a/bench-jmh/src/main/java/org/example/jmh/MyViewAdapter.java
+++ b/bench-jmh/src/main/java/org/example/jmh/MyViewAdapter.java
@@ -58,7 +58,7 @@ public class MyViewAdapter implements JsonAdapter<SomePropertyData>, ViewBuilder
 
   @Override
   public void toJson(JsonWriter writer, SomePropertyData somePropertyData) {
-    writer.beginObject();
+    writer.beginObject(10);
     writer.name("firstNameProperty1");
     stringJsonAdapter.toJson(writer, somePropertyData.getProp1());
     writer.name("lastNameProperty2");

--- a/blackbox-test/src/main/java/org/example/other/custom/CustomClassJsonAdapter.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/CustomClassJsonAdapter.java
@@ -21,7 +21,7 @@ public class CustomClassJsonAdapter implements JsonAdapter<CustomClass> {
   @Override
   public void toJson(JsonWriter writer, CustomClass value) {
 
-    writer.beginObject(names);
+    writer.beginObject(names, 1);
     writer.name(0);
     stringJsonAdapter.toJson(writer, value.body());
     writer.endObject();

--- a/blackbox-test/src/main/java/org/example/other/custom/CustomEntryJsonAdapter.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/CustomEntryJsonAdapter.java
@@ -31,7 +31,7 @@ class CustomEntryJsonAdapter<K, V> implements JsonAdapter<Entry<K, V>> {
   @Override
   public void toJson(JsonWriter writer, Entry<K, V> value) {
 
-    writer.beginObject(names);
+    writer.beginObject(names, 2);
     writer.name(0);
     generic1.toJson(writer, value.getKey());
     writer.name(1);

--- a/blackbox-test/src/main/java/org/example/other/custom/WrapMap2JsonAdapter.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/WrapMap2JsonAdapter.java
@@ -25,7 +25,7 @@ public class WrapMap2JsonAdapter implements JsonAdapter<WrapMap2> {
 
   @Override
   public void toJson(JsonWriter writer, WrapMap2 wrapMap) {
-    writer.beginObject();
+    writer.beginObject(wrapMap.size());
     wrapMap.forEach(
         (key, value) -> {
           writer.name(key);

--- a/blackbox-test/src/main/java/org/example/other/custom/WrapMapJsonAdapter.java
+++ b/blackbox-test/src/main/java/org/example/other/custom/WrapMapJsonAdapter.java
@@ -25,7 +25,7 @@ public class WrapMapJsonAdapter implements JsonAdapter<WrapMap> {
 
   @Override
   public void toJson(JsonWriter writer, WrapMap wrapMap) {
-    writer.beginObject();
+    writer.beginObject(wrapMap.size());
     wrapMap.forEach(
         (key, value) -> {
           writer.name(key);

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -303,7 +303,7 @@ try (JsonReader reader = jsonb.reader(arrayJson)) {
 
 // Write streaming
 try (JsonWriter writer = jsonb.writer(outputStream)) {
-  writer.beginArray();
+  writer.beginArray(users.length);
   for (User user : users) {
     userType.toJson(user, writer);
   }

--- a/json-core/src/main/java/io/avaje/json/JsonWriter.java
+++ b/json-core/src/main/java/io/avaje/json/JsonWriter.java
@@ -110,6 +110,14 @@ public interface JsonWriter extends Closeable, Flushable {
   void beginArray();
 
   /**
+   * Write array begin with a predetermined length.
+   * @param length Number of elements the array contains.
+   */
+  default void beginArray(int length) {
+    beginArray();
+  }
+
+  /**
    * Write array end.
    */
   void endArray();
@@ -125,9 +133,29 @@ public interface JsonWriter extends Closeable, Flushable {
   void beginObject();
 
   /**
-   * Write object being and use the already encoded property names.
+   * Write object begin with a predetermined size.
+   * @param size Number of fields this object contains.
    */
-  void beginObject(PropertyNames names);
+  default void beginObject(int size) {
+    beginObject();
+  }
+
+  /**
+   * Write object begin and use the already encoded property names.
+   * @param names Pre-encoded property names.
+   */
+  default void beginObject(PropertyNames names) {
+    beginObject();
+  }
+
+  /**
+   * Write object begin with a predetermined size and use the already encoded property names.
+   * @param names Pre-encoded property names.
+   * @param size  Number of fields this object contains.
+   */
+  default void beginObject(PropertyNames names, int size) {
+    beginObject(names);
+  }
 
   /**
    * Write object end.

--- a/json-core/src/main/java/io/avaje/json/core/ArrayAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/core/ArrayAdapter.java
@@ -62,7 +62,7 @@ final class ArrayAdapter implements JsonAdapter<Object> {
 
   @Override
   public void toJson(JsonWriter writer, Object value) {
-    writer.beginArray();
+    writer.beginArray(Array.getLength(value));
     for (int i = 0, size = Array.getLength(value); i < size; i++) {
       elementAdapter.toJson(writer, Array.get(value, i));
     }

--- a/json-core/src/main/java/io/avaje/json/core/CollectionAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/core/CollectionAdapter.java
@@ -91,7 +91,7 @@ abstract class CollectionAdapter<C extends Collection<T>, T> implements ViewBuil
       writer.emptyArray();
       return;
     }
-    writer.beginArray();
+    writer.beginArray(value.size());
     for (T element : value) {
       elementAdapter.toJson(writer, element);
     }

--- a/json-core/src/main/java/io/avaje/json/core/MapAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/core/MapAdapter.java
@@ -41,7 +41,7 @@ final class MapAdapter<V> implements JsonAdapter<Map<String, V>> {
 
   @Override
   public void toJson(JsonWriter writer, Map<String, V> map) {
-    writer.beginObject();
+    writer.beginObject(map.size());
     for (var entry : map.entrySet()) {
       if (entry.getKey() == null) {
         throw new JsonDataException("Map key is null at " + writer.path());

--- a/json-core/src/test/java/io/avaje/json/mapper/CustomAdapter2Test.java
+++ b/json-core/src/test/java/io/avaje/json/mapper/CustomAdapter2Test.java
@@ -46,9 +46,9 @@ class CustomAdapter2Test {
 
     @Override
     public void toJson(JsonWriter writer, MyOtherType value) {
-      writer.beginObject(names);
+      writer.beginObject(names, 2);
       writer.name(0);
-      // writer.beginObject();
+      // writer.beginObject(2);
       // writer.name("foo");
       writer.value(value.foo);
       writer.name(1);

--- a/json-node/src/main/java/io/avaje/json/node/adapter/ArrayAdapter.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/ArrayAdapter.java
@@ -34,7 +34,7 @@ final class ArrayAdapter implements JsonAdapter<JsonArray> {
       writer.emptyArray();
       return;
     }
-    writer.beginArray();
+    writer.beginArray(value.size());
     for (JsonNode element : value.elements()) {
       elementAdapter.toJson(writer, element);
     }

--- a/json-node/src/main/java/io/avaje/json/node/adapter/ObjectAdapter.java
+++ b/json-node/src/main/java/io/avaje/json/node/adapter/ObjectAdapter.java
@@ -23,7 +23,7 @@ final class ObjectAdapter implements JsonAdapter<JsonObject> {
 
   @Override
   public void toJson(JsonWriter writer, JsonObject value) {
-    writer.beginObject();
+    writer.beginObject(value.size());
     for (var entry : value.elements().entrySet()) {
       if (entry.getKey() == null) {
         throw new JsonDataException("Map key is null at " + writer.path());

--- a/json-node/src/test/java/io/avaje/json/node/CustomAdapterTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/CustomAdapterTest.java
@@ -136,7 +136,7 @@ class CustomAdapterTest {
 
     @Override
     public void toJson(JsonWriter writer, MyCustomType value) {
-      writer.beginObject(names);
+      writer.beginObject(names, 2);
       writer.name(0);
       writer.value(value.foo);
       writer.name(1);

--- a/json-node/src/test/java/io/avaje/json/node/adapter/WrapJsonObjectJsonAdapter.java
+++ b/json-node/src/test/java/io/avaje/json/node/adapter/WrapJsonObjectJsonAdapter.java
@@ -29,7 +29,7 @@ public final class WrapJsonObjectJsonAdapter implements JsonAdapter<WrapJsonObje
 
   @Override
   public void toJson(JsonWriter writer, WrapJsonObject _wrapJsonObject) {
-    writer.beginObject(names);
+    writer.beginObject(names, 1);
     writer.name(0);
     jsonObjectJsonAdapter.toJson(writer, _wrapJsonObject.json);
     writer.endObject();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -376,10 +376,10 @@ final class ClassReader implements BeanReader {
       writer.eol();
       writer.append("  @Override").eol();
       writer.append("  public void toJson(JsonWriter writer, %s %s) {", shortName, varName).eol();
-      writer.append("    writer.beginObject(names);").eol();
       if (hasSubTypes) {
         writeToJsonForSubtypes(writer, varName);
       } else {
+        writer.append("    writer.beginObject(names, %d);", allFields.size()).eol();
         writeToJsonForType(writer, varName, "    ", null);
       }
       writer.append("    writer.endObject();").eol();
@@ -403,6 +403,13 @@ final class ClassReader implements BeanReader {
           writer.append("    %s (%s instanceof %s) {", elseIf, varName, subTypeShort).eol();
           writer.append("      %s sub = (%s) %s;", subTypeShort, subTypeShort, varName).eol();
         }
+        writer.append(
+          "    writer.beginObject(names, %d);",
+          1 + allFields.stream()
+            .map(field -> field.subTypes())
+            .filter(subTypes -> subTypes.isEmpty() || subTypes.containsKey(type))
+            .count()
+        ).eol();
         writer.append("      writer.name(0);").eol();
         writer.append("      stringJsonAdapter.toJson(writer, \"%s\");", subTypeName).eol();
         writeToJsonForType(writer, "sub", "      ", subType);

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/CustomEntryJsonAdapter.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/CustomEntryJsonAdapter.java
@@ -32,7 +32,7 @@ public class CustomEntryJsonAdapter<K, V> implements JsonAdapter<java.util.Map.E
 
   @Override
   public void toJson(JsonWriter writer, Entry<K, V> value) {
-    writer.beginObject(names);
+    writer.beginObject(names, 2);
     writer.name(0);
     generic1.toJson(writer, value.getKey());
     writer.name(1);

--- a/jsonb-jackson/src/test/java/org/example/AddressJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/AddressJsonAdapter.java
@@ -41,7 +41,7 @@ public class AddressJsonAdapter implements ViewBuilderAware, JsonAdapter<Address
 
   @Override
   public void toJson(JsonWriter writer, Address address) {
-    writer.beginObject(names);
+    writer.beginObject(names, 3);
     writer.name(0);
     stringAdapter.toJson(writer, address.street());
     writer.name(1);

--- a/jsonb-jackson/src/test/java/org/example/CustomerJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/CustomerJsonAdapter.java
@@ -50,7 +50,7 @@ public class CustomerJsonAdapter implements ViewBuilderAware, JsonAdapter<Custom
 
   @Override
   public void toJson(JsonWriter writer, Customer customer) {
-    writer.beginObject(names);
+    writer.beginObject(names, 5);
     writer.name( 0);
     intAdapter.toJson(writer, customer.id());
     writer.name( 1);

--- a/jsonb-jackson/src/test/java/org/example/MyBasicJsonAdapter.java
+++ b/jsonb-jackson/src/test/java/org/example/MyBasicJsonAdapter.java
@@ -48,7 +48,7 @@ public final class MyBasicJsonAdapter implements ViewBuilderAware, JsonAdapter<S
 
   @Override
   public void toJson(JsonWriter writer, StreamBasicTest.MyBasic myBasic) {
-    writer.beginObject(names);
+    writer.beginObject(names, 2);
     writer.name(0);
     pintJsonAdapter.toJson(writer, myBasic.id);
     writer.name(1);

--- a/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/BasicTypeAdapters.java
@@ -218,7 +218,7 @@ final class BasicTypeAdapters {
         int end = Math.min(MAX_STACK, stackTrace.length);
         List<StackTraceElement> stackTraceElements = Arrays.asList(stackTrace).subList(0, end);
         writer.name("stackTrace");
-        writer.beginArray();
+        writer.beginArray(stackTraceElements.size());
         for (StackTraceElement element : stackTraceElements) {
           stackTraceElementAdapter.toJson(writer, element);
         }
@@ -233,7 +233,7 @@ final class BasicTypeAdapters {
       final Throwable[] suppressed = value.getSuppressed();
       if (suppressed != null && suppressed.length > 0) {
         writer.name("suppressed");
-        writer.beginArray();
+        writer.beginArray(suppressed.length);
         for (Throwable sup : suppressed) {
           toJson(writer, sup);
         }
@@ -360,7 +360,7 @@ final class BasicTypeAdapters {
     public void toJson(JsonWriter writer, Object value) {
       final Class<?> valueClass = value.getClass();
       if (valueClass == Object.class) {
-        writer.beginObject();
+        writer.beginObject(0);
         writer.endObject();
       } else if (value instanceof Optional) {
         final var op = (Optional<Object>) value;

--- a/jsonb/src/main/java/io/avaje/jsonb/core/CoreViewBuilder.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/CoreViewBuilder.java
@@ -282,7 +282,7 @@ final class CoreViewBuilder implements ViewBuilder {
     @Override
     public void write(JsonWriter writer, Object object) {
       try {
-        writer.beginObject();
+        writer.beginObject(elements.length);
         for (final Element element : elements) {
           element.write(writer, object);
         }
@@ -309,7 +309,7 @@ final class CoreViewBuilder implements ViewBuilder {
     public void write(JsonWriter writer, Object object) {
       try {
         writer.name(namePosition);
-        writer.beginObject();
+        writer.beginObject(elements.length);
         final Object nested = methodHandle.invoke(object);
         for (final Element element : elements) {
           element.write(writer, nested);
@@ -336,7 +336,7 @@ final class CoreViewBuilder implements ViewBuilder {
       if (collection.isEmpty()) {
         writer.emptyArray();
       } else {
-        writer.beginArray();
+        writer.beginArray(collection.size());
         for (final Object value : collection) {
           child.toJson(value, writer);
         }
@@ -366,7 +366,7 @@ final class CoreViewBuilder implements ViewBuilder {
         if (collection.isEmpty()) {
           writer.emptyArray();
         } else {
-          writer.beginArray();
+          writer.beginArray(collection.size());
           for (final Object value : collection) {
             child.toJson(value, writer);
           }

--- a/jsonb/src/main/java/io/avaje/jsonb/core/EnumMapAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/EnumMapAdapter.java
@@ -36,7 +36,7 @@ final class EnumMapAdapter<K extends Enum<K>, V> implements JsonAdapter<Map<K, V
 
   @Override
   public void toJson(JsonWriter writer, Map<K, V> map) {
-    writer.beginObject();
+    writer.beginObject(map.size());
     for (final var entry : map.entrySet()) {
       if (entry.getKey() == null) {
         throw new JsonDataException("Map key is null at " + writer.path());

--- a/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/StreamAdapter.java
@@ -32,7 +32,7 @@ final class StreamAdapter<T> implements DJsonClosable<Stream<T>>, JsonAdapter<St
         });
         writer.writeNewLine();
       } else {
-        writer.beginArray();
+        writer.beginArray(); // It is impossible to know the length of a stream without consuming its elements
         stream.forEach(bean -> elementAdapter.toJson(writer, bean));
         writer.endArray();
       }


### PR DESCRIPTION
To support bounded structures for binary formats for #472, this adds new overrides to `beginObject` and `beginArray` in `JsonWriter` that provides the size of the object/array. Draft for now, since this goes against some of the discussion in that issue and I'd like to see how it actually works with a binary format writer. Writers will still need to be able to handle unbounded objects/arrays.