### PR TITLE
Add Javalin Mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,3 +266,19 @@ When using Spring Web, you can use the following dependency to use avaje-jsonb f
 </dependency>
 ```
 
+### Optional support for Javalin
+When using Javalin, you can use the following dependency to use avaje-jsonb for HTTP serialization:
+```xml
+<dependency>
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-jsonb-javalin-mapper</artifactId>
+  <version>${avaje-jsonb-version}</version>
+</dependency>
+```
+
+An instance of `JavalinJsonb` will need passed to the Javalin configuration to enable the integration.
+```java
+Javalin app = Javalin.create(config -> {
+  config.jsonMapper(new JavalinJsonb());
+});
+```

--- a/jsonb-bom/pom.xml
+++ b/jsonb-bom/pom.xml
@@ -57,6 +57,11 @@
         <artifactId>avaje-jsonb-spring-starter</artifactId>
         <version>3.14</version>
       </dependency>
+      <dependency>
+        <groupId>io.avaje</groupId>
+        <artifactId>avaje-jsonb-javalin-mapper</artifactId>
+        <version>3.14</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/jsonb-javalin-mapper/pom.xml
+++ b/jsonb-javalin-mapper/pom.xml
@@ -41,6 +41,8 @@
       <optional>true</optional>
     </dependency>
 
+    <!-- Test dependencies -->
+
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
@@ -48,6 +50,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb-generator</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.konghq</groupId>
@@ -55,6 +63,13 @@
       <version>3.14.5</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+  </dependency>
 
   </dependencies>
 

--- a/jsonb-javalin-mapper/pom.xml
+++ b/jsonb-javalin-mapper/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>avaje-jsonb-parent</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>3.14</version>
+  </parent>
+
+  <artifactId>avaje-jsonb-javalin-mapper</artifactId>
+  <name>avaje jsonb javalin mapper</name>
+  <description>Javalin mapper for avaje-jsonb</description>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.javalin</groupId>
+      <artifactId>javalin</artifactId>
+      <version>7.2.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-jsonb</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-spi-service</artifactId>
+      <version>${spi.version}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.8</version>
+      <scope>test</scope>
+    </dependency>
+
+
+    <dependency>
+      <groupId>com.konghq</groupId>
+      <artifactId>unirest-java</artifactId>
+      <version>3.14.5</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/jsonb-javalin-mapper/pom.xml
+++ b/jsonb-javalin-mapper/pom.xml
@@ -73,4 +73,13 @@
 
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/jsonb-javalin-mapper/src/main/java/io/avaje/jsonb/javalin/JavalinJsonb.java
+++ b/jsonb-javalin-mapper/src/main/java/io/avaje/jsonb/javalin/JavalinJsonb.java
@@ -1,0 +1,77 @@
+package io.avaje.jsonb.javalin;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import io.avaje.jsonb.Jsonb;
+import io.javalin.json.JsonMapper;
+import io.javalin.json.PipedStreamExecutor;
+
+public class JavalinJsonb implements JsonMapper {
+  protected final Jsonb jsonb;
+  protected final boolean useVirtualThreads;
+  protected PipedStreamExecutor pipedStreamExecutor = null;
+
+  public JavalinJsonb() {
+    this(Jsonb.instance(), false);
+  }
+
+  public JavalinJsonb(Jsonb jsonb) {
+    this(jsonb, false);
+  }
+
+  public JavalinJsonb(boolean useVirtualThreads) {
+    this(Jsonb.instance(), useVirtualThreads);
+  }
+
+  public JavalinJsonb(Jsonb jsonb, boolean useVirtualThreads) {
+    this.jsonb = jsonb;
+    this.useVirtualThreads = useVirtualThreads;
+  }
+
+  @Override
+  public String toJsonString(Object obj, Type type) {
+    if (obj instanceof String) {
+      return (String) obj;
+    } else {
+      return jsonb.type(type).toJson(obj);
+    }
+  }
+
+  @Override
+  public InputStream toJsonStream(Object obj, Type type) {
+    if (obj instanceof String) {
+      return new ByteArrayInputStream(((String) obj).getBytes(StandardCharsets.UTF_8));
+    } else {
+      if (pipedStreamExecutor == null) pipedStreamExecutor = new PipedStreamExecutor(useVirtualThreads);
+      return pipedStreamExecutor.getInputStream(outputStream -> {
+        jsonb.type(type).toJson(obj, outputStream);
+      });
+    }
+  }
+
+  @Override
+  public void writeToOutputStream(Stream<?> stream, OutputStream outputStream) {
+    try (var writer = jsonb.writer(outputStream)){
+      writer.beginArray();
+      stream.forEach(it -> jsonb.toJson(it, writer));
+      writer.endArray();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T fromJsonString(String json, Type targetType) {
+    return (T) jsonb.type(targetType).fromJson(json);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T fromJsonStream(InputStream json, Type targetType) {
+    return (T) jsonb.type(targetType).fromJson(json);
+  }
+}

--- a/jsonb-javalin-mapper/src/main/java/module-info.java
+++ b/jsonb-javalin-mapper/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.avaje.jsonb.javalin {
+
+  requires transitive io.avaje.jsonb;
+  requires transitive io.javalin;
+  requires static io.avaje.spi;
+
+  exports io.avaje.jsonb.javalin;
+}

--- a/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/JavalinJsonbTest.java
+++ b/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/JavalinJsonbTest.java
@@ -1,0 +1,127 @@
+package io.avaje.jsonb.javalin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.Json;
+import io.avaje.jsonb.Jsonb;
+import io.javalin.Javalin;
+import io.javalin.json.JsonMapper;
+import kong.unirest.HttpRequestWithBody;
+import kong.unirest.Unirest;
+
+// This is a port of Javalin's JSON tests from Kotlin to Java
+public class JavalinJsonbTest {
+  @Json
+  static class Foo {
+    public final long value;
+
+    Foo(long value) {
+      this.value = value;
+    }
+  }
+
+  static Javalin appWithJsonb() {
+    return Javalin.create(config -> {
+      config.jsonMapper(new JavalinJsonb());
+    });
+  }
+
+  @Test
+  @DisplayName("JavalinJsonb can convert a small Stream to JSON")
+  void smallStreamToJSON() {
+    List<Foo> source = List.of(new Foo(1_000_000), new Foo(1_000_001));
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    new JavalinJsonb().writeToOutputStream(source.stream(), baos);
+    assertThat(baos.toString(StandardCharsets.UTF_8)).isEqualTo("[{\"value\":1000000},{\"value\":1000001}]");
+  }
+
+  static class CountingOutputStream extends OutputStream {
+    int count = 0;
+
+    @Override
+    public void write(int b) throws IOException {
+      count++;
+    }
+  }
+
+  @Test
+  @DisplayName("JavalinJsonb can convert a large Stream to JSON")
+  void largeStreamToJSON() {
+    JsonMapper jsonMapper = new JavalinJsonb();
+    long valueLength = 1_000_000;
+    int oneElementLength = jsonMapper.toJsonString(new Foo(valueLength), Foo.class).length();
+    int numElements = 50_000;
+    Stream<Foo> sequence = LongStream.iterate(valueLength, i -> i + 1).mapToObj(i -> new Foo(i)).limit(numElements);
+    CountingOutputStream countingOutputStream = new CountingOutputStream();
+    jsonMapper.writeToOutputStream(sequence, countingOutputStream);
+    int expectedCharacterCount = 2 + // bookend brackets
+        (numElements - 1) + // commas
+        oneElementLength * numElements; // elements
+    assertThat(countingOutputStream.count).isEqualTo(expectedCharacterCount);
+  }
+
+  static String getBody(Javalin app, String endpoint) {
+    return Unirest.get(String.format("http://localhost:%d%s", app.port(), endpoint)).asString().getBody();
+  }
+
+  static HttpRequestWithBody post(Javalin app, String endpoint) {
+    return Unirest.post(String.format("http://localhost:%d%s", app.port(), endpoint));
+  }
+
+  @Test
+  @DisplayName("user can serialize objects using avaje-jsonb mapper")
+  void serialize() {
+    Javalin app = appWithJsonb().start(0);
+    app.unsafe.routes.get("/", context -> context.json(new SerializableObject()));
+    assertThat(getBody(app, "/")).isEqualTo(Jsonb.instance().toJson(new SerializableObject()));
+    app.stop();
+  }
+
+  @Test
+  @DisplayName("user can deserialize objects using avaje-jsonb mapper")
+  void deserialize() {
+    Javalin app = appWithJsonb().start(0);
+    app.unsafe.routes.post("/", context -> context.result(context.bodyAsClass(SerializableObject.class).value1));
+    assertThat(post(app, "/").body(Jsonb.instance().toJson(new SerializableObject())).asString().getBody())
+        .isEqualTo(new SerializableObject().value1);
+    app.stop();
+  }
+
+  @Test
+  @DisplayName("JavalinJsonb properly handles json stream")
+  void stream() {
+    Javalin app = appWithJsonb().start(0);
+    app.unsafe.routes.get("/", context -> context.jsonStream(Stream.of("1")));
+    assertThat(getBody(app, "/")).isEqualTo("[\"1\"]");
+    app.stop();
+  }
+
+  @Test
+  @DisplayName("toJsonStream treats Strings as already being json")
+  void streamStrings() {
+    Javalin app = appWithJsonb().start(0);
+    app.unsafe.routes.get("/", context -> context.jsonStream("{a:b}"));
+    assertThat(getBody(app, "/")).isEqualTo("{a:b}");
+    app.stop();
+  }
+
+  @Test
+  @DisplayName("toJson treats Strings as already being json")
+  void stringStrings() {
+    Javalin app = appWithJsonb().start(0);
+    app.unsafe.routes.get("/", context -> context.json("{a:b}"));
+    assertThat(getBody(app, "/")).isEqualTo("{a:b}");
+    app.stop();
+  }
+}

--- a/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/JavalinJsonbTest.java
+++ b/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/JavalinJsonbTest.java
@@ -102,7 +102,7 @@ public class JavalinJsonbTest {
   @DisplayName("JavalinJsonb properly handles json stream")
   void stream() {
     Javalin app = appWithJsonb().start(0);
-    app.unsafe.routes.get("/", context -> context.jsonStream(Stream.of("1")));
+    app.unsafe.routes.get("/", context -> context.jsonStream(new String[] {"1"}));
     assertThat(getBody(app, "/")).isEqualTo("[\"1\"]");
     app.stop();
   }

--- a/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/SerializableObject.java
+++ b/jsonb-javalin-mapper/src/test/java/io/avaje/jsonb/javalin/SerializableObject.java
@@ -1,0 +1,9 @@
+package io.avaje.jsonb.javalin;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public class SerializableObject {
+  public String value1 = "FirstValue";
+  public String value2 = "SecondValue";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <module>jsonb-jackson</module>
     <module>jsonb-inject-plugin</module>
     <module>jsonb-spring-adapter</module>
+    <module>jsonb-javalin-mapper</module>
     <module>jsonb-bom</module>
   </modules>
 


### PR DESCRIPTION
This adds a new artifact `avaje-jsonb-javalin-mapper`, containing `JavalinJsonb` to integrate with Javalin's API. This is equivalent to the contents of javalin/Javalin#2599.