### PR TITLE
#542 Remove the internal JParser.ErrorInfo error description levels

### DIFF
--- a/json-core/src/main/java/io/avaje/json/stream/core/HybridBufferRecycler.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/HybridBufferRecycler.java
@@ -217,7 +217,6 @@ final class HybridBufferRecycler implements BufferRecycler {
         new char[Recyclers.PARSER_CHAR_BUFFER_SIZE],
         new byte[Recyclers.PARSER_BUFFER_SIZE],
         0,
-        JParser.ErrorInfo.MINIMAL,
         JParser.DoublePrecision.DEFAULT,
         JParser.UnknownNumberParsing.BIGDECIMAL,
         Recyclers.PARSER_MAX_NUMBER_DIGITS,

--- a/json-core/src/main/java/io/avaje/json/stream/core/JParser.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JParser.java
@@ -21,13 +21,6 @@ import java.util.Formatter;
  */
 class JParser implements JsonParser {
 
-  enum ErrorInfo {
-    WITH_STACK_TRACE,
-    DESCRIPTION_AND_POSITION,
-    DESCRIPTION_ONLY,
-    MINIMAL
-  }
-
   enum DoublePrecision {
     EXACT(0),
     HIGH(1),
@@ -89,7 +82,6 @@ class JParser implements JsonParser {
   private final ArrayDeque<JsonNames> nameStack = new ArrayDeque<>();
   private JsonNames currentNames;
 
-  final ErrorInfo errorInfo;
   final DoublePrecision doublePrecision;
   final int doubleLengthLimit;
   final UnknownNumberParsing unknownNumbers;
@@ -100,7 +92,6 @@ class JParser implements JsonParser {
     final char[] tmp,
     final byte[] buffer,
     final int length,
-    final ErrorInfo errorInfo,
     final DoublePrecision doublePrecision,
     final UnknownNumberParsing unknownNumbers,
     final int maxNumberDigits,
@@ -110,7 +101,6 @@ class JParser implements JsonParser {
     this.length = length;
     this.bufferLenWithExtraSpace = buffer.length - 38; // maximum padding is for uuid
     this.chars = tmp;
-    this.errorInfo = errorInfo;
     this.doublePrecision = doublePrecision;
     this.unknownNumbers = unknownNumbers;
     this.maxNumberDigits = maxNumberDigits;
@@ -1073,7 +1063,6 @@ class JParser implements JsonParser {
     error.append(description);
     error.append(", instead found '");
     error.append((char) last).append("'");
-    //if (errorInfo == ErrorInfo.DESCRIPTION_ONLY) return ParsingException.create(formatErrorMessage(), false);
     error.append(" ");
     positionDescription(0, error);
     return new JsonDataException(errorMessage());
@@ -1084,9 +1073,6 @@ class JParser implements JsonParser {
   }
 
   final JsonDataException newParseErrorAt(final String description, final int offset) {
-    if (errorInfo == ErrorInfo.MINIMAL || errorInfo == ErrorInfo.DESCRIPTION_ONLY) {
-      return new JsonDataException(description);
-    }
     error.setLength(0);
     error.append(description);
     error.append(" ");
@@ -1096,7 +1082,6 @@ class JParser implements JsonParser {
 
   final JsonDataException newParseErrorAt(final String description, final int offset, final Exception cause) {
     if (cause == null) throw new IllegalArgumentException("cause can't be null");
-    if (errorInfo == ErrorInfo.MINIMAL) return new JsonDataException(description, cause);
     error.setLength(0);
     final String msg = cause.getMessage();
     if (msg != null && msg.length() > 0) {
@@ -1107,17 +1092,14 @@ class JParser implements JsonParser {
       error.append(" ");
     }
     error.append(description);
-    //if (errorInfo == ErrorInfo.DESCRIPTION_ONLY) return new JsonDataException(formatErrorMessage(), cause);
     error.append(" ");
     positionDescription(offset, error);
     return new JsonDataException(errorMessage());
   }
 
   final JsonDataException newParseErrorFormat(final String description, final int offset, final String extraFormat, Object... args) {
-    if (errorInfo == ErrorInfo.MINIMAL) return new JsonDataException(description);
     error.setLength(0);
     errorFormatter.format(extraFormat, args);
-    //if (errorInfo == ErrorInfo.DESCRIPTION_ONLY) return ParsingException.create(formatErrorMessage(), false);
     error.append(" ");
     positionDescription(offset, error);
     return new JsonDataException(errorMessage());
@@ -1128,14 +1110,12 @@ class JParser implements JsonParser {
   }
 
   final JsonDataException newParseErrorWith(String description, int offset, String extra, Object extraArgument, String extraSuffix) {
-    if (errorInfo == ErrorInfo.MINIMAL) return new JsonDataException(description);
     error.setLength(0);
     error.append(extra);
     if (extraArgument != null) {
       error.append(": '").append(extraArgument).append("'");
     }
     error.append(extraSuffix);
-    //if (errorInfo == ErrorInfo.DESCRIPTION_ONLY) return ParsingException.create(formatErrorMessage(), false);
     error.append(" ");
     positionDescription(offset, error);
     return new JsonDataException(errorMessage());

--- a/json-core/src/main/java/io/avaje/json/stream/core/Recyclers.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/Recyclers.java
@@ -28,7 +28,6 @@ final class Recyclers {
         ch,
         by,
         0,
-        JParser.ErrorInfo.MINIMAL,
         JParser.DoublePrecision.DEFAULT,
         JParser.UnknownNumberParsing.BIGDECIMAL,
         PARSER_MAX_NUMBER_DIGITS,

--- a/json-core/src/test/java/io/avaje/json/stream/core/JParserTest.java
+++ b/json-core/src/test/java/io/avaje/json/stream/core/JParserTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JParserTest {
 
-  final JParser.ErrorInfo errorInfo = JParser.ErrorInfo.MINIMAL;
   final JParser.DoublePrecision doublePrecision = JParser.DoublePrecision.HIGH;
   final JParser.UnknownNumberParsing unknownNumbers = JParser.UnknownNumberParsing.BIGDECIMAL;
   final int maxNumberDigits = 100;
@@ -131,6 +130,6 @@ class JParserTest {
   private JParser newParser(int len) {
     final char[] tmp = new char[len];
     final byte[] buffer = new byte[len];
-    return new JParser(tmp, buffer, buffer.length, errorInfo, doublePrecision, unknownNumbers, maxNumberDigits, maxStringBuffer);
+    return new JParser(tmp, buffer, buffer.length, doublePrecision, unknownNumbers, maxNumberDigits, maxStringBuffer);
   }
 }

--- a/json-core/src/test/java/io/avaje/json/stream/core/JsonReadAdapterTest.java
+++ b/json-core/src/test/java/io/avaje/json/stream/core/JsonReadAdapterTest.java
@@ -21,7 +21,7 @@ class JsonReadAdapterTest {
   void via_jreader() {
     char[] ch = new char[1000];
     byte[] by = new byte[1000];
-    JParser jr = new JParser(ch, by, 0, JParser.ErrorInfo.MINIMAL, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 50_000);
+    JParser jr = new JParser(ch, by, 0, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 50_000);
 
     byte[] bytes = jsonStringInput.getBytes(StandardCharsets.UTF_8);
     jr.process(bytes, bytes.length);
@@ -97,7 +97,7 @@ class JsonReadAdapterTest {
   void readString_millionChars_withLargeLimit() {
     char[] ch = new char[4096];
     byte[] by = new byte[4096];
-    JParser jr = new JParser(ch, by, 0, JParser.ErrorInfo.MINIMAL, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 2_000_000);
+    JParser jr = new JParser(ch, by, 0, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 2_000_000);
 
     String bigVal = "a".repeat(1_000_000);
     byte[] bytes = ("{\"content\":\"" + bigVal + "\"}").getBytes(StandardCharsets.UTF_8);
@@ -115,7 +115,7 @@ class JsonReadAdapterTest {
   void readString_millionChars_defaultLimit_throws() {
     char[] ch = new char[4096];
     byte[] by = new byte[4096];
-    JParser jr = new JParser(ch, by, 0, JParser.ErrorInfo.MINIMAL, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 50_000);
+    JParser jr = new JParser(ch, by, 0, JParser.DoublePrecision.DEFAULT, JParser.UnknownNumberParsing.BIGDECIMAL, 100, 50_000);
 
     String bigVal = "a".repeat(1_000_000);
     byte[] bytes = ("{\"content\":\"" + bigVal + "\"}").getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
Remove JParser.ErrorInfo enum and just simplify to json parser exceptions to always include the details