### PR TITLE
Fix imports for nested class subtypes from external modules.

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/subtype/ImportedBase.java
+++ b/blackbox-test/src/main/java/org/example/customer/subtype/ImportedBase.java
@@ -1,0 +1,10 @@
+package org.example.customer.subtype;
+
+import io.avaje.jsonb.Json;
+import org.example.customer.subtype.subpackage.Imported;
+
+@Json
+@Json.SubType(type = Imported.Subtype.class)
+public interface ImportedBase {
+  String getName();
+}

--- a/blackbox-test/src/main/java/org/example/customer/subtype/subpackage/Imported.java
+++ b/blackbox-test/src/main/java/org/example/customer/subtype/subpackage/Imported.java
@@ -1,0 +1,18 @@
+package org.example.customer.subtype.subpackage;
+
+import org.example.customer.subtype.ImportedBase;
+
+public class Imported {
+  public static class Subtype implements ImportedBase {
+    private String name = "Subtype of Imported";
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/subtype/ImportedBaseTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/subtype/ImportedBaseTest.java
@@ -1,0 +1,26 @@
+package org.example.customer.subtype;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+import org.example.customer.subtype.subpackage.Imported;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ImportedBaseTest {
+
+  Jsonb jsonb = Jsonb.builder().build();
+  JsonType<ImportedBase> type = jsonb.type(ImportedBase.class);
+
+  @Test
+  void toJson_fromJson_subtypeInSubpackage() {
+    Imported.Subtype subtype = new Imported.Subtype();
+    subtype.setName("hello");
+
+    String json = type.toJson(subtype);
+    ImportedBase result = type.fromJson(json);
+
+    assertThat(result).isInstanceOf(Imported.Subtype.class);
+    assertThat(result.getName()).isEqualTo("hello");
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ClassReader.java
@@ -81,7 +81,7 @@ final class ClassReader implements BeanReader {
     this.methodProperties = typeReader.methodProperties();
     this.pkgPrivate = typeReader.isPkgPrivate();
 
-    subTypes.stream().map(TypeSubTypeMeta::type).forEach(importTypes::add);
+    subTypes.stream().map(TypeSubTypeMeta::baseType).forEach(importTypes::add);
 
     final var userTypeField = allFields.stream().filter(f -> f.propertyName().equals(typePropertyKey())).findAny();
     this.usesTypeProperty = userTypeField.isPresent();

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeSubTypeMeta.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/TypeSubTypeMeta.java
@@ -13,6 +13,7 @@ final class TypeSubTypeMeta {
 
   private final String type;
   private String name;
+  private final String baseType;
   private final String shortType;
   private TypeElement typeElement;
   private boolean defaultPublicConstructor;
@@ -27,6 +28,7 @@ final class TypeSubTypeMeta {
   TypeSubTypeMeta(SubTypePrism prism) {
     type = prism.type().toString();
     name = Util.escapeQuotes(prism.name());
+    baseType = Util.baseType(type);
     shortType = Util.shortType(type);
   }
 
@@ -36,6 +38,10 @@ final class TypeSubTypeMeta {
 
   TypeElement element() {
     return typeElement;
+  }
+
+  String baseType() {
+    return baseType;
   }
 
   String type() {
@@ -105,7 +111,6 @@ final class TypeSubTypeMeta {
   private boolean isIncludeSetter(FieldReader field) {
     return field.includeFromJson() && !constructorFieldNames.contains(field.fieldName()) && field.includeForType(this);
   }
-
 
   private void writeFromJsonConstructor(Append writer, String varName, SubTypeRequest req) {
     writer.append("      %s _$%s = new %s(", shortType, varName, shortType);

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/Util.java
@@ -59,6 +59,30 @@ final class Util {
     }
   }
 
+  /** Returns the type identifier up to and including the first class */
+  static String baseType(String fullType) {
+    final int p = fullType.lastIndexOf('.');
+    if (p == -1 || fullType.startsWith("java")) {
+      return fullType;
+    } else {
+      var result = "";
+      for (final String part : fullType.split("\\.")) {
+        result += (result.isEmpty() ? "" : ".") + part;
+        char firstChar = part.charAt(0);
+        if (Character.isUpperCase(firstChar)
+            || (!Character.isAlphabetic(firstChar) && Character.isJavaIdentifierStart(firstChar))) {
+          break;
+        }
+      }
+      // when in doubt, do the basic thing
+      if (result.isBlank()) {
+        return fullType;
+      }
+      return result;
+    }
+  }
+
+  /** Returns the type identifier starting from the first class */
   static String shortType(String fullType) {
     final int p = fullType.lastIndexOf('.');
     if (p == -1) {

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/ImportedBase.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/ImportedBase.java
@@ -1,0 +1,10 @@
+package io.avaje.jsonb.generator.models.valid.subtype;
+
+import io.avaje.jsonb.Json;
+import io.avaje.jsonb.generator.models.valid.subtype.subpackage.Imported;
+
+@Json
+@Json.SubType(type = Imported.Subtype.class)
+public interface ImportedBase {
+  String getName();
+}

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/subpackage/Imported.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/subtype/subpackage/Imported.java
@@ -1,0 +1,12 @@
+package io.avaje.jsonb.generator.models.valid.subtype.subpackage;
+
+import io.avaje.jsonb.generator.models.valid.subtype.ImportedBase;
+
+public class Imported {
+  public static class Subtype implements ImportedBase {
+    @Override
+    public String getName() {
+      return "Subtype of Imported";
+    }
+  }
+}


### PR DESCRIPTION
If a subtype is a nested class from an external module, e.g. `com.example.subpackage.Outer.Inner` as a subtype of `com.example.Base`, the wrong import would be used to reference `Outer.Inner` since its fully qualified name would be used instead of `Outer`. This adds a `baseType` utility to get the full name of the outer class (`com.example.subpackage.Outer`) so that the correct type is imported for `shortType` (`Outer.Inner`) to refer to the desired type.

The test introduced in this PR only seems to fail without the second commit of this PR when combined with #552, hence why I think that one is also attempting to compile the generated files.