### PR TITLE
Fix for @Json annotation on plain enum, should be ignored

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/enums/JsonValueEnum.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/JsonValueEnum.java
@@ -1,0 +1,26 @@
+package org.example.customer.enums;
+
+import io.avaje.jsonb.Json;
+
+/**
+ * An enum annotated with both {@code @Json} and {@code @Json.Value}.
+ *
+ * <p>{@code @Json.Value} is what drives generation of a custom adapter here
+ * - {@code @Json} on the type itself has no additional effect.
+ */
+@Json
+public enum JsonValueEnum {
+  ONE("one-code"),
+  TWO("two-code");
+
+  public final String code;
+
+  JsonValueEnum(String code) {
+    this.code = code;
+  }
+
+  @Json.Value
+  public String getCode() {
+    return code;
+  }
+}

--- a/blackbox-test/src/main/java/org/example/customer/enums/JsonValueEnumHolder.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/JsonValueEnumHolder.java
@@ -1,0 +1,13 @@
+package org.example.customer.enums;
+
+import java.util.List;
+
+import io.avaje.jsonb.Json;
+
+/**
+ * Wraps {@link JsonValueEnum} as a single field and as a list field, to
+ * verify the enum works correctly when used inside another {@code @Json}
+ * type (not just as a raw/top level type).
+ */
+@Json
+public record JsonValueEnumHolder(String name, JsonValueEnum value, List<JsonValueEnum> values) {}

--- a/blackbox-test/src/main/java/org/example/customer/enums/PlainJsonEnum.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/PlainJsonEnum.java
@@ -1,0 +1,12 @@
+package org.example.customer.enums;
+
+import io.avaje.jsonb.Json;
+
+/**
+ * A plain enum annotated with {@code @Json} (ignored by the generator).
+ */
+@Json
+public enum PlainJsonEnum {
+  ONE,
+  TWO
+}

--- a/blackbox-test/src/main/java/org/example/customer/enums/PlainJsonEnumHolder.java
+++ b/blackbox-test/src/main/java/org/example/customer/enums/PlainJsonEnumHolder.java
@@ -1,0 +1,8 @@
+package org.example.customer.enums;
+
+import java.util.List;
+
+import io.avaje.jsonb.Json;
+
+@Json
+public record PlainJsonEnumHolder(String name, PlainJsonEnum value, List<PlainJsonEnum> values) {}

--- a/blackbox-test/src/test/java/org/example/customer/enums/JsonValueEnumTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/enums/JsonValueEnumTest.java
@@ -1,0 +1,51 @@
+package org.example.customer.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+
+class JsonValueEnumTest {
+
+  final Jsonb jsonb = Jsonb.instance();
+
+  @Test
+  void rawSingleValue_toFromJson() {
+    final JsonType<JsonValueEnum> type = jsonb.type(JsonValueEnum.class);
+
+    assertThat(type.toJson(JsonValueEnum.ONE)).isEqualTo("\"one-code\"");
+    assertThat(type.toJson(JsonValueEnum.TWO)).isEqualTo("\"two-code\"");
+
+    assertThat(type.fromJson("\"one-code\"")).isEqualTo(JsonValueEnum.ONE);
+    assertThat(type.fromJson("\"two-code\"")).isEqualTo(JsonValueEnum.TWO);
+  }
+
+  @Test
+  void rawListOfValues_toFromJson() {
+    final JsonType<List<JsonValueEnum>> listType = jsonb.type(JsonValueEnum.class).list();
+
+    final List<JsonValueEnum> values = List.of(JsonValueEnum.ONE, JsonValueEnum.TWO, JsonValueEnum.ONE);
+    final String json = listType.toJson(values);
+    assertThat(json).isEqualTo("[\"one-code\",\"two-code\",\"one-code\"]");
+
+    final List<JsonValueEnum> fromJson = listType.fromJson(json);
+    assertThat(fromJson).containsExactly(JsonValueEnum.ONE, JsonValueEnum.TWO, JsonValueEnum.ONE);
+  }
+
+  @Test
+  void wrappedInRecord_toFromJson() {
+    final JsonType<JsonValueEnumHolder> type = jsonb.type(JsonValueEnumHolder.class);
+
+    final var bean = new JsonValueEnumHolder("bean-1", JsonValueEnum.TWO, List.of(JsonValueEnum.ONE, JsonValueEnum.TWO));
+
+    final String json = type.toJson(bean);
+    assertThat(json).isEqualTo("{\"name\":\"bean-1\",\"value\":\"two-code\",\"values\":[\"one-code\",\"two-code\"]}");
+
+    final JsonValueEnumHolder fromJson = type.fromJson(json);
+    assertThat(fromJson).isEqualTo(bean);
+  }
+}

--- a/blackbox-test/src/test/java/org/example/customer/enums/PlainJsonEnumTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/enums/PlainJsonEnumTest.java
@@ -1,0 +1,51 @@
+package org.example.customer.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.jsonb.JsonType;
+import io.avaje.jsonb.Jsonb;
+
+class PlainJsonEnumTest {
+
+  final Jsonb jsonb = Jsonb.instance();
+
+  @Test
+  void rawSingleValue_toFromJson() {
+    final JsonType<PlainJsonEnum> type = jsonb.type(PlainJsonEnum.class);
+
+    assertThat(type.toJson(PlainJsonEnum.ONE)).isEqualTo("\"ONE\"");
+    assertThat(type.toJson(PlainJsonEnum.TWO)).isEqualTo("\"TWO\"");
+
+    assertThat(type.fromJson("\"ONE\"")).isEqualTo(PlainJsonEnum.ONE);
+    assertThat(type.fromJson("\"TWO\"")).isEqualTo(PlainJsonEnum.TWO);
+  }
+
+  @Test
+  void rawListOfValues_toFromJson() {
+    final JsonType<List<PlainJsonEnum>> listType = jsonb.type(PlainJsonEnum.class).list();
+
+    final List<PlainJsonEnum> values = List.of(PlainJsonEnum.ONE, PlainJsonEnum.TWO, PlainJsonEnum.ONE);
+    final String json = listType.toJson(values);
+    assertThat(json).isEqualTo("[\"ONE\",\"TWO\",\"ONE\"]");
+
+    final List<PlainJsonEnum> fromJson = listType.fromJson(json);
+    assertThat(fromJson).containsExactly(PlainJsonEnum.ONE, PlainJsonEnum.TWO, PlainJsonEnum.ONE);
+  }
+
+  @Test
+  void wrappedInRecord_toFromJson() {
+    final JsonType<PlainJsonEnumHolder> type = jsonb.type(PlainJsonEnumHolder.class);
+
+    final var bean = new PlainJsonEnumHolder("bean-1", PlainJsonEnum.TWO, List.of(PlainJsonEnum.ONE, PlainJsonEnum.TWO));
+
+    final String json = type.toJson(bean);
+    assertThat(json).isEqualTo("{\"name\":\"bean-1\",\"value\":\"TWO\",\"values\":[\"ONE\",\"TWO\"]}");
+
+    final PlainJsonEnumHolder fromJson = type.fromJson(json);
+    assertThat(fromJson).isEqualTo(bean);
+  }
+}

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/JsonbProcessor.java
@@ -380,11 +380,19 @@ public final class JsonbProcessor extends AbstractProcessor {
     if (valueElements.contains(typeElement.toString())) {
       return;
     }
+    if (typeElement.getKind() == ElementKind.ENUM) {
+      logNote(typeElement, "Ignoring @Json on enum %s, built in enum support is used instead. Add @Json.Value if custom serialization is required.", typeElement.getSimpleName());
+      return;
+    }
     writeAdapter(typeElement, new ClassReader(typeElement, ""));
   }
 
   private void writeAdapterForType(TypeElement typeElement, Optional<String> adapterPackage) {
     if (valueElements.contains(typeElement.toString())) {
+      return;
+    }
+    if (typeElement.getKind() == ElementKind.ENUM) {
+      logNote(typeElement, "Ignoring @Json on enum %s, built in enum support is used instead. Add @Json.Value if custom serialization is required.", typeElement.getSimpleName());
       return;
     }
     writeAdapter(typeElement, new ClassReader(typeElement, "", adapterPackage));


### PR DESCRIPTION
Currently it does NOT get ignored and tries to generate an adapter and generates incorrect code that can fail to compile. The compile error depends on the JDK version.

This fix, is that the type level @Json annotation on an enum is ignored.