### PR TITLE
Public field Optional deserialization

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/optional/Optionals.java
+++ b/blackbox-test/src/main/java/org/example/customer/optional/Optionals.java
@@ -16,6 +16,8 @@ public class Optionals {
   OptionalDouble doubleOp = OptionalDouble.empty();
   OptionalLong longOp = OptionalLong.empty();
 
+  public Optional<String> publicOp = Optional.empty();
+
   public Optional<String> getStringyString() {
     return stringyString;
   }
@@ -66,7 +68,7 @@ public class Optionals {
 
   @Override
   public int hashCode() {
-    return Objects.hash(doubleOp, intOp, longOp, stringyString);
+    return Objects.hash(doubleOp, intOp, longOp, stringyString, publicOp);
   }
 
   @Override
@@ -77,6 +79,7 @@ public class Optionals {
     return Objects.equals(doubleOp, other.doubleOp)
         && Objects.equals(intOp, other.intOp)
         && Objects.equals(longOp, other.longOp)
-        && Objects.equals(stringyString, other.stringyString);
+        && Objects.equals(stringyString, other.stringyString)
+        && Objects.equals(publicOp, other.publicOp);
   }
 }

--- a/blackbox-test/src/test/java/org/example/customer/optional/OptionalsTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/optional/OptionalsTest.java
@@ -2,6 +2,9 @@ package org.example.customer.optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+import java.util.OptionalInt;
+
 import org.junit.jupiter.api.Test;
 
 import io.avaje.jsonb.Jsonb;
@@ -52,6 +55,7 @@ class OptionalsTest {
     optionals.setIntOp(21);
     optionals.setDoubleOp(6.9);
     optionals.setLongOp(420);
+    optionals.publicOp = Optional.empty();
     return optionals;
   }
 

--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/FieldProperty.java
@@ -344,6 +344,8 @@ final class FieldProperty {
       writer.append("%s    _$%s.%s(_val$%s);", prefix, varName, setter.getName(), fieldName + num).eol();
     } else if (setter != null) {
       writer.append("%s    if (_set$%s) _$%s.%s(_val$%s);", prefix, fieldName + num, varName, setter.getName(), fieldName + num).eol();
+    } else if (publicField && optional) {
+      writer.append("%s    _$%s.%s = _val$%s;", prefix, varName, fieldName, fieldName + num).eol();
     } else if (publicField) {
       writer.append("%s    if (_set$%s) _$%s.%s = _val$%s;", prefix, fieldName + num, varName, fieldName, fieldName + num).eol();
     }

--- a/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Optionals.java
+++ b/jsonb-generator/src/test/java/io/avaje/jsonb/generator/models/valid/Optionals.java
@@ -16,6 +16,8 @@ public class Optionals {
   OptionalLong longOp;
   String stringyString;
 
+  public Optional<String> publicOp = Optional.empty();
+
   public Optional<String> getOp() {
     return op;
   }


### PR DESCRIPTION
Previously, if an optional was only accessable via a public field, it would depend on the generated `_set$name` variable existing, which also woudn't be generated since `Optional.empty` is used to represent a missing field. This fixes that case by copying the behavior if a setter is found, always setting the optional field.