### PR TITLE
Override skipping fields

### DIFF
--- a/json-core/src/main/java/io/avaje/json/JsonWriter.java
+++ b/json-core/src/main/java/io/avaje/json/JsonWriter.java
@@ -70,6 +70,11 @@ public interface JsonWriter extends Closeable, Flushable {
   boolean serializeEmpty();
 
   /**
+   * Forces serialization of the next value, regardless of it being null or empty
+   */
+  void forceSerialize();
+
+  /**
    * Set tp true to output json in pretty format.
    */
   void pretty(boolean pretty);

--- a/json-core/src/main/java/io/avaje/json/stream/DelegateJsonWriter.java
+++ b/json-core/src/main/java/io/avaje/json/stream/DelegateJsonWriter.java
@@ -43,6 +43,11 @@ public abstract class DelegateJsonWriter implements JsonWriter {
   }
 
   @Override
+  public final void forceSerialize() {
+    delegate.forceSerialize();
+  }
+
+  @Override
   public final void pretty(boolean pretty) {
     delegate.pretty(pretty);
   }

--- a/json-core/src/main/java/io/avaje/json/stream/core/JsonWriteAdapter.java
+++ b/json-core/src/main/java/io/avaje/json/stream/core/JsonWriteAdapter.java
@@ -15,6 +15,7 @@ final class JsonWriteAdapter implements JsonWriter {
   private final BufferRecycler recycler;
   private boolean serializeEmpty;
   private boolean serializeNulls;
+  private boolean forceNext;
   private String deferredName;
   private int namePos = -1;
 
@@ -69,6 +70,11 @@ final class JsonWriteAdapter implements JsonWriter {
   @Override
   public void serializeEmpty(boolean serializeEmpty) {
     this.serializeEmpty = serializeEmpty;
+  }
+
+  @Override
+  public void forceSerialize() {
+    this.forceNext = true;
   }
 
   @Override
@@ -127,11 +133,12 @@ final class JsonWriteAdapter implements JsonWriter {
       generator.writeName(deferredName);
       deferredName = null;
     }
+    forceNext = false;
   }
 
   @Override
   public void emptyArray() {
-    if (serializeEmpty) {
+    if (serializeEmpty || forceNext) {
       writeDeferredName();
       generator.startArray();
       generator.endArray();
@@ -144,7 +151,7 @@ final class JsonWriteAdapter implements JsonWriter {
 
   @Override
   public void nullValue() {
-    if (serializeNulls) {
+    if (serializeNulls || forceNext) {
       writeDeferredName();
       generator.writeNull();
     } else if (namePos >= 0) {

--- a/json-core/src/test/java/io/avaje/json/stream/core/ForcedWriteTest.java
+++ b/json-core/src/test/java/io/avaje/json/stream/core/ForcedWriteTest.java
@@ -1,0 +1,65 @@
+package io.avaje.json.stream.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.avaje.json.JsonAdapter;
+import io.avaje.json.JsonWriter;
+import io.avaje.json.core.CoreTypes;
+import io.avaje.json.stream.JsonStream;
+
+public class ForcedWriteTest {
+  JsonStream stream = CoreJsonStream.builder().serializeNulls(false).serializeEmpty(false).build();
+
+  JsonAdapter<Boolean> booleanAdapter = CoreTypes.create(Boolean.class);
+  JsonAdapter<List<Integer>> intListAdapter = CoreTypes.createList(CoreTypes.create(Integer.class));
+
+  @Test
+  void forcedWrite_nullObject() throws IOException {
+    StringWriter sw = new StringWriter();
+    JsonWriter writer = stream.writer(sw);
+
+    writer.beginObject();
+    writer.name("true");
+    booleanAdapter.toJson(writer, true);
+    writer.forceSerialize();
+    writer.name("forcedNull");
+    booleanAdapter.toJson(writer, null);
+    writer.name("skippedNull");
+    booleanAdapter.toJson(writer, null);
+    writer.endObject();
+
+    writer.close();
+    String asJson = sw.toString();
+    sw.close();
+
+    assertThat(asJson).isEqualTo("{\"true\":true,\"forcedNull\":null}");
+  }
+
+  @Test
+  void forcedWrite_emptyList() throws IOException {
+    StringWriter sw = new StringWriter();
+    JsonWriter writer = stream.writer(sw);
+
+    writer.beginObject();
+    writer.name("contents");
+    intListAdapter.toJson(writer, List.of(2, 3));
+    writer.forceSerialize();
+    writer.name("forcedEmpty");
+    intListAdapter.toJson(writer, List.of());
+    writer.name("skippedEmpty");
+    intListAdapter.toJson(writer, List.of());
+    writer.endObject();
+
+    writer.close();
+    String asJson = sw.toString();
+    sw.close();
+
+    assertThat(asJson).isEqualTo("{\"contents\":[2,3],\"forcedEmpty\":[]}");
+  }
+}

--- a/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
+++ b/jsonb-jackson/src/main/java/io/avaje/jsonb/jackson/JacksonWriter.java
@@ -18,6 +18,7 @@ final class JacksonWriter implements JsonWriter {
   private final JsonGenerator generator;
   private boolean serializeEmpty;
   private boolean serializeNulls;
+  private boolean forceNext;
   private String deferredName;
   private final ArrayDeque<JacksonNames> nameStack = new ArrayDeque<>();
   private JacksonNames currentNames;
@@ -88,6 +89,11 @@ final class JacksonWriter implements JsonWriter {
   @Override
   public void serializeEmpty(boolean serializeEmpty) {
     this.serializeEmpty = serializeEmpty;
+  }
+
+  @Override
+  public void forceSerialize() {
+    this.forceNext = true;
   }
 
   @Override
@@ -177,11 +183,12 @@ final class JacksonWriter implements JsonWriter {
       generator.writeFieldName(deferredName);
       deferredName = null;
     }
+    forceNext = false;
   }
 
   @Override
   public void emptyArray() {
-    if (serializeEmpty) {
+    if (serializeEmpty || forceNext) {
       try {
         writeDeferredName();
         generator.writeStartArray();
@@ -199,7 +206,7 @@ final class JacksonWriter implements JsonWriter {
   @Override
   public void nullValue() {
     try {
-      if (serializeNulls) {
+      if (serializeNulls || forceNext) {
         writeDeferredName();
         generator.writeNull();
       } else if (namePos >= 0) {


### PR DESCRIPTION
For the first point of #558, this adds a `forceSerialize` method to `JsonWriter` to override skipping fields. This is implemented with a flag that is set when `forceSerialize` is called and reset when `writeDeferredName` is called, since all value writers and nested constructs make a call to `writeDifferedName` before writing their contents.