### PR TITLE
Fix Optional deserialization of null

### DIFF
--- a/blackbox-test/src/main/java/org/example/customer/optional/Optionals.java
+++ b/blackbox-test/src/main/java/org/example/customer/optional/Optionals.java
@@ -82,4 +82,19 @@ public class Optionals {
         && Objects.equals(stringyString, other.stringyString)
         && Objects.equals(publicOp, other.publicOp);
   }
+
+  @Override
+  public String toString() {
+    return "Optionals[doubleOp="
+        + doubleOp
+        + ", intOp="
+        + intOp
+        + ", longOp="
+        + longOp
+        + ", stringyString="
+        + stringyString
+        + ", publicOp="
+        + publicOp
+        + "]";
+  }
 }

--- a/blackbox-test/src/test/java/org/example/customer/optional/OptionalsTest.java
+++ b/blackbox-test/src/test/java/org/example/customer/optional/OptionalsTest.java
@@ -3,8 +3,8 @@ package org.example.customer.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
-import java.util.OptionalInt;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 import io.avaje.jsonb.Jsonb;
@@ -15,6 +15,7 @@ class OptionalsTest {
       "{\"stringyString\":\"StringyMcStringFace\",\"intOp\":21,\"doubleOp\":6.9,\"longOp\":420}";
 
   Jsonb jsonb = Jsonb.builder().serializeEmpty(false).build();
+  Jsonb jsonbNull = Jsonb.builder().serializeNulls(true).build();
 
   @Test
   void anyToJson() {
@@ -25,12 +26,24 @@ class OptionalsTest {
   }
 
   @Test
-  void nullJson() {
+  void emptyJson() {
     final var optionals = new Optionals();
 
     final var optionalsType = jsonb.type(Optionals.class);
     final String asJson = optionalsType.toJson(optionals);
     assertThat(asJson).isEqualTo("{}");
+
+    final Optionals from2 = optionalsType.fromJson(asJson);
+    assertThat(from2).isEqualTo(optionals);
+  }
+
+  @Test
+  void nullJson() {
+    final var optionals = new Optionals();
+
+    final var optionalsType = jsonbNull.type(Optionals.class);
+    final String asJson = optionalsType.toJson(optionals);
+    assertThat(asJson).isEqualTo("{\"stringyString\":null,\"intOp\":null,\"doubleOp\":null,\"longOp\":null,\"publicOp\":null}");
 
     final Optionals from2 = optionalsType.fromJson(asJson);
     assertThat(from2).isEqualTo(optionals);
@@ -48,7 +61,7 @@ class OptionalsTest {
     assertThat(from2).isEqualTo(optionals);
   }
 
-  private Optionals optionals() {
+  private @NonNull Optionals optionals() {
     final var optionals = new Optionals();
 
     optionals.setStringyString("StringyMcStringFace");

--- a/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
@@ -21,13 +21,13 @@ final class OptionalAdapters {
   static final AdapterFactory FACTORY = (type, jsonb) -> {
     if (Types.isGenericTypeOf(type, Optional.class)) {
       final Type[] args = Types.typeArguments(type);
-      return new OptionalAdapter<>(jsonb, args[0]).nullSafe();
+      return new OptionalAdapter<>(jsonb, args[0]);
     } else if (type == OptionalInt.class) {
-      return new OptionalIntAdapter().nullSafe();
+      return new OptionalIntAdapter();
     } else if (type == OptionalDouble.class) {
-      return new OptionalDoubleAdapter().nullSafe();
+      return new OptionalDoubleAdapter();
     } else if (type == OptionalLong.class) {
-      return new OptionalLongAdapter().nullSafe();
+      return new OptionalLongAdapter();
     }
     return null;
   };
@@ -37,7 +37,8 @@ final class OptionalAdapters {
     private final JsonAdapter<T> delegate;
 
     OptionalAdapter(Jsonb jsonb, Type param0) {
-      this.delegate = jsonb.adapter(param0);
+      JsonAdapter<T> base = jsonb.adapter(param0);
+      this.delegate = base.nullSafe();
     }
 
     @Override
@@ -69,7 +70,11 @@ final class OptionalAdapters {
   static final class OptionalIntAdapter implements JsonAdapter<OptionalInt> {
     @Override
     public OptionalInt fromJson(JsonReader reader) {
-      return OptionalInt.of(reader.readInt());
+      if (reader.isNullValue()) {
+        return OptionalInt.empty();
+      } else {
+        return OptionalInt.of(reader.readInt());
+      }
     }
 
     @Override
@@ -86,7 +91,11 @@ final class OptionalAdapters {
   static final class OptionalDoubleAdapter implements JsonAdapter<OptionalDouble> {
     @Override
     public OptionalDouble fromJson(JsonReader reader) {
-      return OptionalDouble.of(reader.readDouble());
+      if (reader.isNullValue()) {
+        return OptionalDouble.empty();
+      } else {
+        return OptionalDouble.of(reader.readDouble());
+      }
     }
 
     @Override
@@ -103,7 +112,11 @@ final class OptionalAdapters {
   static final class OptionalLongAdapter implements JsonAdapter<OptionalLong> {
     @Override
     public OptionalLong fromJson(JsonReader reader) {
-      return OptionalLong.of(reader.readLong());
+      if (reader.isNullValue()) {
+        return OptionalLong.empty();
+      } else {
+        return OptionalLong.of(reader.readLong());
+      }
     }
 
     @Override

--- a/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
@@ -37,8 +37,7 @@ final class OptionalAdapters {
     private final JsonAdapter<T> delegate;
 
     OptionalAdapter(Jsonb jsonb, Type param0) {
-      JsonAdapter<T> base = jsonb.adapter(param0);
-      this.delegate = base.nullSafe();
+      this.delegate = jsonb.adapter(param0);
     }
 
     @Override

--- a/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
+++ b/jsonb/src/main/java/io/avaje/jsonb/core/OptionalAdapters.java
@@ -42,7 +42,11 @@ final class OptionalAdapters {
 
     @Override
     public void toJson(JsonWriter writer, Optional<T> value) {
-      delegate.toJson(writer, value.orElse(null));
+      if (value == null) {
+        writer.nullValue();
+      } else {
+        delegate.toJson(writer, value.orElse(null));
+      }
     }
 
     @Override
@@ -78,7 +82,11 @@ final class OptionalAdapters {
 
     @Override
     public void toJson(JsonWriter writer, OptionalInt value) {
-      value.ifPresentOrElse(writer::value, writer::nullValue);
+      if (value == null) {
+        writer.nullValue();
+      } else {
+        value.ifPresentOrElse(writer::value, writer::nullValue);
+      }
     }
 
     @Override
@@ -99,7 +107,11 @@ final class OptionalAdapters {
 
     @Override
     public void toJson(JsonWriter writer, OptionalDouble value) {
-      value.ifPresentOrElse(writer::value, writer::nullValue);
+      if (value == null) {
+        writer.nullValue();
+      } else {
+        value.ifPresentOrElse(writer::value, writer::nullValue);
+      }
     }
 
     @Override
@@ -120,7 +132,11 @@ final class OptionalAdapters {
 
     @Override
     public void toJson(JsonWriter writer, OptionalLong value) {
-      value.ifPresentOrElse(writer::value, writer::nullValue);
+      if (value == null) {
+        writer.nullValue();
+      } else {
+        value.ifPresentOrElse(writer::value, writer::nullValue);
+      }
     }
 
     @Override


### PR DESCRIPTION
If `serializeNulls` is set to true, an empty Optional would be serialized as JSON `null`, but deserialized as Java `null` instead of an empty Optional. While both Java `null` and empty Optional map onto JSON `null`, I think the vast majority of use cases would want to use an empty Optional over `null`. This changes the deserialization of Optionals to recognize `null` and return an empty Optional.