### PR TITLE
json-node: Fix NPE in JsonObject copy() and unmodifiable()

### DIFF
--- a/json-node/src/main/java/io/avaje/json/node/JsonObject.java
+++ b/json-node/src/main/java/io/avaje/json/node/JsonObject.java
@@ -75,18 +75,26 @@ public final class JsonObject implements JsonNode {
   public JsonObject unmodifiable() {
     final var mapCopy = new LinkedHashMap<String, JsonNode>();
     for (Map.Entry<String, JsonNode> entry : children.entrySet()) {
-      mapCopy.put(entry.getKey(), entry.getValue().unmodifiable());
+      mapCopy.put(entry.getKey(), _unmodifiable(entry.getValue()));
     }
     return JsonObject.of(mapCopy);
+  }
+
+  private static JsonNode _unmodifiable(JsonNode value) {
+    return value == null ? null : value.unmodifiable();
   }
 
   @Override
   public JsonObject copy() {
     final var mapCopy = new LinkedHashMap<String, JsonNode>();
     for (Map.Entry<String, JsonNode> entry : children.entrySet()) {
-      mapCopy.put(entry.getKey(), entry.getValue().copy());
+      mapCopy.put(entry.getKey(), _copy(entry.getValue()));
     }
     return new JsonObject(mapCopy);
+  }
+
+  private static JsonNode _copy(JsonNode value) {
+    return value == null ? null : value.copy();
   }
 
   @Override

--- a/json-node/src/test/java/io/avaje/json/node/JsonObjectTest.java
+++ b/json-node/src/test/java/io/avaje/json/node/JsonObjectTest.java
@@ -183,6 +183,34 @@ class JsonObjectTest {
   }
 
   @Test
+  void copy_withNullValues() {
+    JsonObject source = JsonObject.create()
+      .add("value", (JsonNode) null)
+      .add("nested", JsonObject.create().add("value", (JsonNode) null));
+
+    JsonObject copy = source.copy();
+
+    assertThat(copy.elements()).containsKeys("value", "nested");
+    assertThat(copy.elements().get("value")).isNull();
+    assertThat(copy.get("nested").find("value")).isNull();
+    assertThat(copy).isEqualTo(source);
+  }
+
+  @Test
+  void unmodifiable_withNullValues() {
+    JsonNode source = JsonNodeMapper.builder().build()
+      .fromJson("{\"value\":null,\"nested\":{\"value\":null}}");
+
+    JsonObject unmodifiable = ((JsonObject) source).unmodifiable();
+
+    assertThat(unmodifiable.elements()).containsKeys("value", "nested");
+    assertThat(unmodifiable.elements().get("value")).isNull();
+    assertThat(unmodifiable.get("nested").find("value")).isNull();
+    assertThatThrownBy(() -> unmodifiable.add("canMutate", true))
+      .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
   void toPlain() {
     final var source = JsonObject.create()
       .add("name", "foo")


### PR DESCRIPTION
The fix here is to make these null safe.

Note the underlying design is that JSON NULL is represented by Java null in this api, so we need to make these methods null safe.