### PR TITLE
Deduplicate JsonAdapter registrations in GeneratedJsonComponent on incremental builds

### DIFF
--- a/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentMetaData.java
+++ b/jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentMetaData.java
@@ -29,15 +29,31 @@ final class ComponentMetaData {
     Optional.ofNullable(APContext.typeElement(type))
       .flatMap(CustomAdapterPrism::getOptionalOn)
       .filter(not(CustomAdapterPrism::global))
-      .ifPresentOrElse(p -> withTypes.add(type), () -> allTypes.add(type));
+      .ifPresentOrElse(p -> addWithType(type), () -> addUnique(allTypes, type));
   }
 
   void addFactory(String fullName) {
-    factoryTypes.add(fullName);
+    addUnique(factoryTypes, fullName);
   }
 
   void addWithType(String type) {
-    withTypes.add(type);
+    addUnique(withTypes, type);
+  }
+
+  /**
+   * Add the adapter/factory only if not already present. Nested class names are recovered from
+   * the previous component's MetaData annotation with dots (eg {@code a.b.C.DJsonAdapter}) while
+   * freshly generated ones use the dollar form (eg {@code a.b.C$DJsonAdapter}), so compare with
+   * the dollar normalised away.
+   */
+  private static void addUnique(List<String> list, String type) {
+    final String normalized = type.replace('$', '.');
+    for (final String existing : list) {
+      if (existing.replace('$', '.').equals(normalized)) {
+        return;
+      }
+    }
+    list.add(type);
   }
 
   void setFullName(String fullName) {


### PR DESCRIPTION
### Problem
Incremental compilation appends duplicate `builder.add(...)` lines to `GeneratedJsonComponent.register(...)` — one per recompile of a `@Json` type. Root cause: `ComponentMetaData` stores adapters/factories in append-only lists and, on an incremental build, a type is added twice — once recovered from the previous component's `@MetaData` annotation (`ComponentReader`, dot-form nested names like `a.b.C.DJsonAdapter`) and again as a freshly generated adapter (dollar-form like `a.b.C$DJsonAdapter`).

### Change
In `jsonb-generator/src/main/java/io/avaje/jsonb/generator/ComponentMetaData.java`:

- Route `add`, `addFactory` and `addWithType` through a new `addUnique(...)` helper.
- Compare candidates with `$` normalised to `.` so the recovered dot-form and the generated dollar-form of the same nested class are recognised as equal.
- Keeps existing insertion order (first occurrence wins).

### Verification
Reproduced with a nested `@Json` bean compiled twice into the same output dir:
- Before: RUN1 = 1 registration, RUN2 = 2 (duplicate).
- After: RUN1 = 1, RUN2 = 1, RUN3 = 1.

`mvn -pl jsonb-generator -am install` compiles cleanly.